### PR TITLE
docs(schema): fix Site/ExerciseID modulo math in DIS adapter contract

### DIFF
--- a/docs/schema/dis-adapter.md
+++ b/docs/schema/dis-adapter.md
@@ -63,7 +63,7 @@ translates as follows:
 | DIS field | Neutral source | Translation rule |
 |---|---|---|
 | `ExerciseID` (1 byte, `1..255`) | `scenario_id` | Adapter maintains a `(tenant_id, scenario_id) → ExerciseID` lookup table allocated at scenario start. ExerciseID `0` is reserved (DIS convention). 255 active scenarios per adapter instance is the v1 ceiling — flagged as an open question if scenarios-per-tenant exceeds this. |
-| `Site` (16-bit) | `tenant_id` (low 16 bits of a deterministic hash) | Adapter assigns `Site` from a hash of `tenant_id` modulo `2^16 - 1`. Site `0` is reserved. Collisions (>65k tenants) are deferred. |
+| `Site` (16-bit) | `tenant_id` (low 16 bits of a deterministic hash) | Adapter assigns `Site = (hash(tenant_id) mod 65535) + 1`, producing values `1..65535`. Site `0` is reserved (DIS convention) and never assigned. Collisions (>65k tenants) are deferred. |
 | `Application` (16-bit) | adapter-instance ordinal | Each adapter process within a tenant gets a unique Application id. Single-process v1: hardcoded to 1. |
 | `EntityNumber` (16-bit) | `entity_id` (sequence per scenario) | Adapter maintains an `entity_id → EntityNumber` table per `(Site, Application, ExerciseID)`. `EntityNumber = 0` is reserved (DIS) and never assigned. |
 
@@ -314,10 +314,10 @@ is academic, but flagged for completeness.
 
 ### 5.6 Tenant / scenario address collisions
 
-`Site = hash(tenant_id) mod 65535` collides at >65k tenants per adapter
-process. `ExerciseID` is 1 byte and can address 254 scenarios per tenant.
-Both ceilings are far above v1 demo scope but become real problems at
-production scale.
+`Site = (hash(tenant_id) mod 65535) + 1` collides at >65k tenants per adapter
+process. `ExerciseID` is 1 byte and can address 255 scenarios per tenant
+(values `1..255`; `0` is reserved per DIS convention). Both ceilings are
+far above v1 demo scope but become real problems at production scale.
 
 ---
 


### PR DESCRIPTION
## Summary
- **Site formula was wrong.** `mod 65535` yields `0..65534`, not the `1..65535` range the spec claims; Site 0 is DIS-reserved (wildcard) so a tenant whose `hash(tenant_id) mod 65535 == 0` would have its traffic interpreted as broadcast on the wire. Fixed to `(hash(tenant_id) mod 65535) + 1` so Site 0 is unreachable by construction.
- **§ 1.3 and § 5.6 disagreed on the ExerciseID ceiling** (255 vs 254). Aligned on 255: a 1-byte field has 256 values, IEEE 1278.1 reserves only `0`, leaving 255. If we later decide to also reserve 255 (broadcast convention some federates use), that's an implementation policy question, not a contract-doc one.
- § 5.6 also still cited the old Site formula in prose; updated to track the new one.

Follow-up to #39 (WS-102) — these were inline review suggestions that didn't make it in before the merge.

## Test plan
- [ ] Visual diff review: only two textual edits in `docs/schema/dis-adapter.md`, lines 66 and 317–320.
- [ ] CODEOWNERS auto-routes to @devindynamo for the WS-102 file.