### PR TITLE
WS-106 — Capability profile schema

### DIFF
--- a/docs/schema/capability-profile.schema.json
+++ b/docs/schema/capability-profile.schema.json
@@ -1,0 +1,331 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://almighty.dynamo.works/schema/capability-profile.schema.json",
+  "title": "Almighty capability profile",
+  "description": "Structural contract for a v1 Almighty capability profile. Companion semantic spec at docs/schema/capability-profiles.md (WS-106). Cross-officer validation rules (e.g., officer_types_available <-> per-officer block presence; uncertainty restricted to RED) are enforced by the validator (WS-202) at registration time and intentionally not re-encoded here as conditional schemas.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "profile_id",
+    "version",
+    "display_name",
+    "force_affiliation",
+    "officer_types_available",
+    "action_verbs_available",
+    "effect_parameter_ranges",
+    "entity_bindings"
+  ],
+  "properties": {
+    "profile_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "display_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "force_affiliation": {
+      "enum": ["BLUE", "RED", "WHITE", "NEUTRAL"]
+    },
+    "officer_types_available": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/officerType" }
+    },
+    "action_verbs_available": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/actionVerb" }
+    },
+    "sensor": { "$ref": "#/$defs/sensorBlock" },
+    "effector": { "$ref": "#/$defs/effectorBlock" },
+    "mover": { "$ref": "#/$defs/moverBlock" },
+    "communicator": { "$ref": "#/$defs/communicatorBlock" },
+    "commander": { "$ref": "#/$defs/commanderBlock" },
+    "effect_parameter_ranges": { "$ref": "#/$defs/effectParameterRanges" },
+    "uncertainty": { "$ref": "#/$defs/uncertaintyBlock" },
+    "entity_bindings": { "$ref": "#/$defs/entityBindings" },
+    "frozen_at": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "forked_from": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile_id", "version"],
+      "properties": {
+        "profile_id": { "type": "string", "format": "uuid" },
+        "version": { "type": "integer", "minimum": 1 }
+      }
+    }
+  },
+
+  "$defs": {
+    "officerType": {
+      "enum": ["SENSOR", "EFFECTOR", "MOVER", "COMMUNICATOR", "COMMANDER"]
+    },
+
+    "actionVerb": {
+      "enum": [
+        "detect", "track", "classify", "lose_track",
+        "engage", "suppress", "destroy", "disable",
+        "move_to", "follow_route", "halt", "assume_posture",
+        "send", "relay", "jam", "report",
+        "issue_order", "request_support", "delegate", "escalate"
+      ]
+    },
+
+    "sensorModality": {
+      "enum": ["EO_IR", "RF", "RADAR", "ACOUSTIC", "SEISMIC", "MASINT_MULTI"]
+    },
+
+    "rfBand": {
+      "enum": ["HF", "VHF", "UHF", "L", "S", "C", "X", "KU", "KA"]
+    },
+
+    "commsChannel": {
+      "enum": ["VHF", "UHF", "HF", "SATCOM", "DATA"]
+    },
+
+    "posture": {
+      "enum": ["HALTED", "MOUNTED", "DISMOUNTED", "DUG_IN", "ALERT", "REST"]
+    },
+
+    "echelon": {
+      "enum": ["COMPANY", "BATTALION", "BRIGADE", "DIVISION", "WHITE_CELL"]
+    },
+
+    "deliveryMode": {
+      "enum": ["DIRECT", "INDIRECT", "EW", "CYBER"]
+    },
+
+    "supportType": {
+      "enum": ["FIRES", "ISR", "MEDEVAC", "LOGISTICS", "EW", "AIR"]
+    },
+
+    "reportType": {
+      "enum": ["SITREP", "SPOTREP", "LOGSTAT", "CASEVAC", "INTREP"]
+    },
+
+    "effectFamily": {
+      "enum": [
+        "ew_cone", "uas_corridor", "radar_fan", "jamming_circle",
+        "satellite_swath", "indirect_fire_arc", "ir_plume",
+        "masint_cell", "keyhole_footprint"
+      ]
+    },
+
+    "minMaxFloat": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["min", "max"],
+      "properties": {
+        "min": { "type": "number" },
+        "max": { "type": "number" }
+      }
+    },
+
+    "sensorBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["modalities", "max_concurrent_tracks", "max_update_rate_hz", "default_track_lifetime_s"],
+      "properties": {
+        "modalities": {
+          "type": "object",
+          "minProperties": 0,
+          "propertyNames": { "$ref": "#/$defs/sensorModality" },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["max_range_m", "min_classify_dwell_s"],
+            "properties": {
+              "max_range_m": { "type": "number", "exclusiveMinimum": 0 },
+              "min_classify_dwell_s": { "type": "number", "minimum": 0 }
+            }
+          }
+        },
+        "max_concurrent_tracks": { "type": "integer", "minimum": 0 },
+        "max_update_rate_hz": { "type": "number", "exclusiveMinimum": 0 },
+        "default_track_lifetime_s": { "type": "number", "exclusiveMinimum": 0 }
+      }
+    },
+
+    "effectorBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["weapon_systems", "max_suppression_area_m2", "cyber_disable"],
+      "properties": {
+        "weapon_systems": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "delivery_mode", "effective_range_m", "ammo_remaining", "time_of_flight_s", "supported_verbs"],
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "delivery_mode": { "$ref": "#/$defs/deliveryMode" },
+              "effective_range_m": { "type": "number", "exclusiveMinimum": 0 },
+              "ammo_remaining": { "type": "integer", "minimum": 0 },
+              "time_of_flight_s": { "type": "number", "minimum": 0 },
+              "supported_verbs": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": { "enum": ["engage", "suppress", "destroy", "disable"] }
+              }
+            }
+          }
+        },
+        "max_suppression_area_m2": { "type": "number", "minimum": 0 },
+        "cyber_disable": { "type": "boolean" }
+      }
+    },
+
+    "moverBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cruise_speed_mps", "max_speed_mps", "allowed_postures", "posture_transitions"],
+      "properties": {
+        "cruise_speed_mps": { "type": "number", "minimum": 0 },
+        "max_speed_mps": { "type": "number", "minimum": 0 },
+        "allowed_postures": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/posture" }
+        },
+        "posture_transitions": {
+          "type": "object",
+          "propertyNames": { "$ref": "#/$defs/posture" },
+          "additionalProperties": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "$ref": "#/$defs/posture" }
+          }
+        }
+      }
+    },
+
+    "communicatorBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["channels", "bands", "advertise_corridor", "reports_allowed"],
+      "properties": {
+        "channels": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/commsChannel" }
+        },
+        "bands": {
+          "type": "object",
+          "propertyNames": { "$ref": "#/$defs/rfBand" },
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["max_power_w", "max_coverage_area_m2"],
+            "properties": {
+              "max_power_w": { "type": "number", "exclusiveMinimum": 0 },
+              "max_coverage_area_m2": { "type": "number", "exclusiveMinimum": 0 }
+            }
+          }
+        },
+        "advertise_corridor": { "type": "boolean" },
+        "reports_allowed": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reportType" }
+        }
+      }
+    },
+
+    "commanderBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["echelon", "subordinates_under", "delegatable_verbs", "request_support_types", "max_delegation_ttl_turns"],
+      "properties": {
+        "echelon": { "$ref": "#/$defs/echelon" },
+        "subordinates_under": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "delegatable_verbs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/actionVerb" }
+        },
+        "request_support_types": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/supportType" }
+        },
+        "max_delegation_ttl_turns": { "type": "integer", "minimum": 0 }
+      }
+    },
+
+    "effectParameterRanges": {
+      "type": "object",
+      "propertyNames": { "$ref": "#/$defs/effectFamily" },
+      "additionalProperties": {
+        "type": "object",
+        "minProperties": 1,
+        "additionalProperties": { "$ref": "#/$defs/minMaxFloat" }
+      }
+    },
+
+    "uncertaintyBlock": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Dot-separated path into the profile, with array-by-id sugar `[<id>]`. Resolution is the validator's job."
+      },
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["band_pct"],
+            "properties": {
+              "band_pct": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["band_lower", "band_upper"],
+            "properties": {
+              "band_lower": { "type": "number" },
+              "band_upper": { "type": "number" }
+            }
+          }
+        ]
+      }
+    },
+
+    "entityBindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "anyOf": [
+        { "required": ["type_subtype_refs"] },
+        { "required": ["specific_ids"] }
+      ],
+      "properties": {
+        "type_subtype_refs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "specific_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "format": "uuid" }
+        }
+      }
+    }
+  }
+}

--- a/docs/schema/capability-profiles.md
+++ b/docs/schema/capability-profiles.md
@@ -1,0 +1,621 @@
+# Almighty — Capability profile schema (v1)
+
+> **Classification:** UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY
+
+A **capability profile** is the immutable-from-scenario-start description
+of what an entity can do in the simulation. Profiles drive three things:
+
+1. **Agent decision-making** — CrewAI agents (WS-403, WS-404, WS-405)
+   read profiles to know which verbs they can issue and within what bounds.
+2. **Validator gating** — the CZML validator (WS-202) intersects the
+   profile's `effect_parameter_ranges` with the CZML template's static
+   constraints (WS-201) to gate every spatial artifact at commit time.
+3. **Officer-tool capability checks** — the tool wrapper (WS-402) for
+   each verb checks `action_verbs_available` before invoking the validator.
+
+The profile is the single point where an entity's *what it can do* is
+declared. Per-officer blocks (`sensor`, `effector`, `mover`,
+`communicator`, `commander`) name the parameter paths that
+[`officer-interfaces.md`](officer-interfaces.md) (WS-105) references — for
+example, when WS-105 says "`range_m ≤ profile.sensor.<modality>.max_range_m`",
+the path resolves to `<this profile>.sensor.<modality>.max_range_m`.
+
+The companion JSON Schema is at
+[`capability-profile.schema.json`](capability-profile.schema.json) (draft
+2020-12). It is the structural contract; this doc is the semantic one.
+
+---
+
+## 1. Top-level fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `profile_id` | `uuid` | yes | Stable identifier. Edits that materially change profile semantics MUST fork to a new `profile_id` rather than bumping `version` once the profile is bound. |
+| `version` | `int` | yes | Monotonic, ≥ 1. Pre-scenario edits bump version against the same `profile_id`. Frozen at first binding (see [§ 5](#5-versioning)). |
+| `display_name` | `string` | yes | Human-readable for EXCON consoles and AAR. |
+| `force_affiliation` | enum `BLUE \| RED \| WHITE \| NEUTRAL` | yes | Aligned with WS-101. RED profiles MAY include the `uncertainty` block; non-RED profiles MUST NOT. |
+| `officer_types_available` | `[string]` | yes | Subset of `{SENSOR, EFFECTOR, MOVER, COMMUNICATOR, COMMANDER}`. Empty list is legal but rare (e.g., a beacon entity). |
+| `action_verbs_available` | `[string]` | yes | Subset of the 20 verbs in WS-105. Each verb's officer type MUST appear in `officer_types_available` (validation rule, see [§ 4](#4-validation-rules)). |
+| `sensor` | object | conditional | Required iff `SENSOR ∈ officer_types_available`. See [§ 2.1](#21-sensor-block). |
+| `effector` | object | conditional | Required iff `EFFECTOR ∈ officer_types_available`. See [§ 2.2](#22-effector-block). |
+| `mover` | object | conditional | Required iff `MOVER ∈ officer_types_available`. See [§ 2.3](#23-mover-block). |
+| `communicator` | object | conditional | Required iff `COMMUNICATOR ∈ officer_types_available`. See [§ 2.4](#24-communicator-block). |
+| `commander` | object | conditional | Required iff `COMMANDER ∈ officer_types_available`. See [§ 2.5](#25-commander-block). |
+| `effect_parameter_ranges` | object | yes | Per-spatial-effect-family parameter bounds. See [§ 3](#3-effect-parameter-ranges). |
+| `uncertainty` | object | optional | RED-only band declarations. See [§ 6](#6-uncertainty-bands-red-only). |
+| `entity_bindings` | object | yes | Which entities pull this profile. See [§ 7](#7-entity-bindings). |
+| `frozen_at` | `timestamptz` | optional | `null` while the profile is in draft. Set to a UTC timestamp at first binding. Once non-null, edits to `(profile_id, version)` are rejected. |
+| `forked_from` | object | optional | `{ "profile_id": uuid, "version": int }` when this profile was forked from a previously frozen one. Provides AAR provenance. |
+
+---
+
+## 2. Per-officer blocks
+
+### 2.1 `sensor` block
+
+Drives the four Sensor verbs (`detect`, `track`, `classify`, `lose_track`).
+
+```yaml
+sensor:
+  modalities:                 # per-modality config; missing modalities are unavailable
+    EO_IR:        { max_range_m: 8000,  min_classify_dwell_s: 3.0 }
+    RF:           { max_range_m: 80000, min_classify_dwell_s: 2.0 }
+    RADAR:        { max_range_m: 50000, min_classify_dwell_s: 1.0 }
+    ACOUSTIC:     { max_range_m: 4000,  min_classify_dwell_s: 5.0 }
+    SEISMIC:      { max_range_m: 6000,  min_classify_dwell_s: 4.0 }
+    MASINT_MULTI: { max_range_m: 30000, min_classify_dwell_s: 6.0 }
+  max_concurrent_tracks: 24
+  max_update_rate_hz: 5.0
+  default_track_lifetime_s: 120
+```
+
+Modalities are the same set as WS-105's `sensor_modality` enum. A
+modality not declared in `modalities` is implicitly unavailable — the
+validator rejects `detect` calls with that modality.
+
+### 2.2 `effector` block
+
+Drives `engage`, `suppress`, `destroy`, `disable`.
+
+```yaml
+effector:
+  weapon_systems:
+    - id: notional.indirect.medium     # the string referenced in payload.weapon_system
+      delivery_mode: INDIRECT          # DIRECT | INDIRECT | EW | CYBER
+      effective_range_m: 25000
+      ammo_remaining: 240
+      time_of_flight_s: 32             # ballistic feasibility check
+      supported_verbs: [engage, suppress, destroy]
+    - id: notional.direct.smallarms
+      delivery_mode: DIRECT
+      effective_range_m: 600
+      ammo_remaining: 6000
+      time_of_flight_s: 0
+      supported_verbs: [engage, suppress]
+  max_suppression_area_m2: 1500000     # 1.5 km^2; over this -> adjudication
+  cyber_disable: false                 # true unlocks disable.method=CYBER
+```
+
+`weapon_systems[*].id` is the exact string an agent passes in
+`engage.weapon_system`. `supported_verbs` is the per-system gate — a
+5.56 rifle profile lists `[engage, suppress]` only, so a `destroy` call
+with that weapon fails at the validator. `delivery_mode = EW` weapon
+systems borrow the Communicator-side jam capability (WS-105 § 2,
+`disable` method `EW`).
+
+### 2.3 `mover` block
+
+Drives `move_to`, `follow_route`, `halt`, `assume_posture`.
+
+```yaml
+mover:
+  cruise_speed_mps: 12.5
+  max_speed_mps: 22.2
+  allowed_postures: [HALTED, MOUNTED, DISMOUNTED, DUG_IN, ALERT, REST]
+  posture_transitions:        # adjacency list; from -> [to, ...]
+    HALTED:     [MOUNTED, REST, ALERT]
+    MOUNTED:    [HALTED, ALERT]
+    DISMOUNTED: [HALTED, DUG_IN, ALERT]
+    DUG_IN:     [DISMOUNTED, ALERT]
+    ALERT:      [HALTED, MOUNTED, DISMOUNTED, REST]
+    REST:       [ALERT, HALTED]
+```
+
+`posture_transitions` resolves the open question carried over from
+WS-105 § Open Questions. The transition matrix is per-profile because
+different platforms have different doctrinal allowed transitions (e.g.,
+a wheeled APC cannot `DUG_IN` directly without first becoming
+`DISMOUNTED`).
+
+### 2.4 `communicator` block
+
+Drives `send`, `relay`, `jam`, `report`.
+
+```yaml
+communicator:
+  channels: [VHF, UHF, HF, DATA]                     # available comms channels
+  bands:                                             # per-band jam config
+    VHF: { max_power_w: 200,  max_coverage_area_m2: 6000000 }
+    UHF: { max_power_w: 200,  max_coverage_area_m2: 4000000 }
+    L:   { max_power_w: 1000, max_coverage_area_m2: 2000000 }
+  advertise_corridor: false                          # relay -> uas_corridor artifact
+  reports_allowed: [SITREP, SPOTREP, LOGSTAT, INTREP]
+```
+
+Bands not present in `bands` are unavailable to `jam`. A profile with
+`channels = []` cannot `send` at all; `relay` and `report` similarly
+require a `channel` to be available.
+
+### 2.5 `commander` block
+
+Drives `issue_order`, `request_support`, `delegate`, `escalate`.
+
+```yaml
+commander:
+  echelon: BATTALION                                  # COMPANY | BATTALION | BRIGADE | DIVISION | WHITE_CELL
+  subordinates_under: [notional.ground.bct.company]   # type_subtype_refs (entity-binding match)
+  delegatable_verbs: [move_to, engage, suppress, jam] # subset of own action_verbs_available
+  request_support_types: [FIRES, ISR, MEDEVAC, LOGISTICS, EW, AIR]
+  max_delegation_ttl_turns: 6
+```
+
+`subordinates_under` resolves a Commander entity's chain of command at
+binding time: an `issue_order` call's recipient must be an entity whose
+`type_subtype_ref` matches one of these patterns OR be an
+`entity_bindings.specific_ids` member.
+
+---
+
+## 3. Effect parameter ranges
+
+`effect_parameter_ranges` is keyed by spatial-effect-family name (per
+[`docs/glossary.md` § 2](../glossary.md#2-effect-families)). It is the
+profile-side input the validator (WS-202) intersects with the
+template-side static range from WS-201.
+
+```yaml
+effect_parameter_ranges:
+  ew_cone:
+    azimuth_deg:        { min: 0,    max: 359 }
+    beamwidth_deg:      { min: 5,    max: 60 }
+    effective_range_m:  { min: 1000, max: 50000 }
+  jamming_circle:
+    radius_m:           { min: 100,  max: 8000 }
+    power_w:            { min: 10,   max: 1000 }
+  indirect_fire_arc:
+    range_m:            { min: 1000, max: 30000 }
+    dispersion_ellipse_a_m: { min: 5, max: 250 }
+    dispersion_ellipse_b_m: { min: 5, max: 250 }
+    time_of_flight_s:   { min: 1,    max: 90 }
+  radar_fan:
+    sweep_arc_deg:      { min: 5,    max: 360 }
+    range_m:            { min: 500,  max: 80000 }
+  ir_plume:
+    peak_intensity_w_per_sr: { min: 1, max: 5000 }
+    decay_s:            { min: 5,    max: 300 }
+  masint_cell:
+    polygon_area_m2:    { min: 1000, max: 10000000 }
+    dwell_s:            { min: 30,   max: 7200 }
+  keyhole_footprint:
+    polygon_area_m2:    { min: 100,  max: 200000 }
+  uas_corridor:
+    altitude_band_lower_m: { min: 100, max: 10000 }
+    altitude_band_upper_m: { min: 100, max: 12000 }
+  satellite_swath:
+    swath_width_m:      { min: 5000,  max: 250000 }
+    pass_duration_s:    { min: 30,    max: 1800 }
+```
+
+A family that is wholly inapplicable to a profile (e.g., a foot-mobile
+infantry profile with no satellite assets) MAY OMIT that family's entry.
+The validator interprets a missing entry as "this profile cannot emit
+this family at all" and rejects any CZML packet that references it.
+
+---
+
+## 4. Validation rules
+
+The JSON Schema enforces shape; these semantic rules are enforced by the
+validator (WS-202) at scenario-start profile registration:
+
+1. **Officer ↔ verb consistency.** Every verb in `action_verbs_available`
+   must belong to an officer type in `officer_types_available`. Verb-to-
+   officer mapping is the one in WS-105 § Summary.
+2. **Per-officer block presence.** If `X ∈ officer_types_available`, the
+   `<x>` block (lowercased) must be present and non-empty. Conversely, a
+   block for an officer not in `officer_types_available` must be absent.
+3. **Verb-specific field requirements.** Particular verbs imply
+   particular per-officer-block fields:
+   - `engage / suppress / destroy / disable` ⇒ `effector.weapon_systems` non-empty.
+   - `detect / track / classify` ⇒ `sensor.modalities` non-empty.
+   - `jam` ⇒ `communicator.bands` non-empty.
+   - `assume_posture` ⇒ `mover.posture_transitions` covers all postures
+     in `mover.allowed_postures`.
+   - `delegate` ⇒ `commander.delegatable_verbs ⊆ action_verbs_available`.
+4. **Effect-family / verb consistency.** A profile that emits a spatial
+   family (per WS-105 § Summary) must include that family in
+   `effect_parameter_ranges`. The validator looks up the verb's
+   typically-emitted family from a fixed table and rejects at registration
+   time if missing.
+5. **Uncertainty on RED only.** If `uncertainty` is present,
+   `force_affiliation` MUST be `RED`. A WHITE/BLUE/NEUTRAL profile with
+   an `uncertainty` block is rejected.
+
+---
+
+## 5. Versioning
+
+Profiles are mutable in draft and frozen at first binding.
+
+- **Draft state:** `frozen_at = null`. Pre-scenario edits push a new
+  `version` against the same `profile_id`. White cell authors profiles
+  in this state through the white cell console (WS-505).
+- **Frozen state:** `frozen_at = <utc>`. This is set automatically the
+  first time an entity in any scenario binds to `(profile_id, version)`.
+  Any subsequent edit to the *same* `(profile_id, version)` is rejected;
+  the only path forward is a new `version` (if no scenario has bound to
+  the current version) or a fork (new `profile_id`, with `forked_from`
+  set).
+- **Forking:** a fork copies the current profile, assigns a new
+  `profile_id`, sets `version = 1`, and records `forked_from =
+  {profile_id, version}`. AAR (WS-506) renders the lineage when a
+  scenario's profile graph is traversed.
+
+The runbook's "immutable from turn 1" rule is therefore a consequence of
+"immutable from first binding"; turn 1 is just the most common first
+binding event, not a special-cased trigger.
+
+---
+
+## 6. Uncertainty bands (RED only)
+
+Red-side capabilities reflect what the *opponent* believes about the
+adversary, not ground truth. The optional `uncertainty` block declares
+bands on selected fields:
+
+```yaml
+uncertainty:
+  effector.weapon_systems[notional.indirect.medium].effective_range_m:
+    band_pct: 0.20      # ±20% relative
+  sensor.modalities.RADAR.max_range_m:
+    band_pct: 0.30
+  communicator.bands.UHF.max_power_w:
+    band_lower: 50      # absolute lower
+    band_upper: 800     # absolute upper
+```
+
+Resolution rules:
+
+- **Agent reasoning.** Red agents (WS-404) reason over the uncertainty
+  band — e.g., a red S3 issuing an `engage` order computes range
+  feasibility against the *upper bound* of the band when it wants the
+  shot to succeed and against the *lower bound* when it wants to claim
+  it cannot reach.
+- **Validator clamping.** When red emits a CZML packet, the validator
+  clamps the parameter to the upper bound of the band before the
+  effect-family range check. This means red can claim ±20% on its
+  effector range but cannot actually exceed the upper bound on the wire.
+- **AAR transparency.** The white cell sees the unbounded ground-truth
+  value as authored; the band is what the *blue* side, were they
+  observing, would infer.
+- **Uncertainty paths.** The keys in `uncertainty` are JSON-Pointer-style
+  paths into the profile object. Path syntax: dot-separated for objects,
+  square-brackets for array elements addressed by `id` (where applicable)
+  or by index. The JSON Schema validates the path syntax; semantic
+  resolution is the validator's job.
+
+---
+
+## 7. Entity bindings
+
+`entity_bindings` declares which entities use this profile.
+
+```yaml
+entity_bindings:
+  type_subtype_refs:
+    - notional.ground.bct.battalion
+    - notional.ground.bct.hq.command-vehicle
+  specific_ids:
+    - 1c3b8f6e-2c7e-4a8c-9b3d-7a1d2f5e9a01     # one specific entity
+```
+
+Resolution at scenario start:
+
+- An entity's `capability_set_ref` (per WS-101) must match exactly one
+  profile's binding. If `entity_id` is in any profile's `specific_ids`,
+  that profile wins. Otherwise, the entity's `type_subtype_ref` is
+  matched against `type_subtype_refs` of every profile; exactly one must
+  match.
+- Multiple matches at scenario start is a registration error and blocks
+  scenario start.
+- An entity that matches no profile gets the `null_profile`
+  (officer_types_available = [], action_verbs_available = []) and is
+  read-only on the wire (publishes Entity State only).
+
+---
+
+## 8. Worked examples
+
+Two complete profiles follow. Both validate against
+[`capability-profile.schema.json`](capability-profile.schema.json).
+
+### 8.1 Notional US BCT (blue) — `us-bct@1`
+
+A US Brigade Combat Team battalion-level profile. Fully populated; no
+`uncertainty` (BLUE forces don't have it).
+
+```json
+{
+  "profile_id": "00000000-bbbb-0001-0000-000000000001",
+  "version": 1,
+  "display_name": "Notional US BCT — battalion",
+  "force_affiliation": "BLUE",
+  "officer_types_available": ["SENSOR", "EFFECTOR", "MOVER", "COMMUNICATOR", "COMMANDER"],
+  "action_verbs_available": [
+    "detect", "track", "classify", "lose_track",
+    "engage", "suppress", "destroy", "disable",
+    "move_to", "follow_route", "halt", "assume_posture",
+    "send", "relay", "report",
+    "issue_order", "request_support", "delegate", "escalate"
+  ],
+  "sensor": {
+    "modalities": {
+      "EO_IR":        { "max_range_m": 8000,  "min_classify_dwell_s": 3.0 },
+      "RADAR":        { "max_range_m": 50000, "min_classify_dwell_s": 1.0 },
+      "RF":           { "max_range_m": 60000, "min_classify_dwell_s": 2.0 },
+      "MASINT_MULTI": { "max_range_m": 25000, "min_classify_dwell_s": 6.0 }
+    },
+    "max_concurrent_tracks": 32,
+    "max_update_rate_hz": 5.0,
+    "default_track_lifetime_s": 180
+  },
+  "effector": {
+    "weapon_systems": [
+      {
+        "id": "notional.indirect.medium",
+        "delivery_mode": "INDIRECT",
+        "effective_range_m": 25000,
+        "ammo_remaining": 240,
+        "time_of_flight_s": 32,
+        "supported_verbs": ["engage", "suppress", "destroy"]
+      },
+      {
+        "id": "notional.direct.smallarms",
+        "delivery_mode": "DIRECT",
+        "effective_range_m": 600,
+        "ammo_remaining": 12000,
+        "time_of_flight_s": 0,
+        "supported_verbs": ["engage", "suppress"]
+      }
+    ],
+    "max_suppression_area_m2": 1500000,
+    "cyber_disable": false
+  },
+  "mover": {
+    "cruise_speed_mps": 12.5,
+    "max_speed_mps": 22.2,
+    "allowed_postures": ["HALTED", "MOUNTED", "DISMOUNTED", "DUG_IN", "ALERT", "REST"],
+    "posture_transitions": {
+      "HALTED":     ["MOUNTED", "REST", "ALERT"],
+      "MOUNTED":    ["HALTED", "ALERT"],
+      "DISMOUNTED": ["HALTED", "DUG_IN", "ALERT"],
+      "DUG_IN":     ["DISMOUNTED", "ALERT"],
+      "ALERT":      ["HALTED", "MOUNTED", "DISMOUNTED", "REST"],
+      "REST":       ["ALERT", "HALTED"]
+    }
+  },
+  "communicator": {
+    "channels": ["VHF", "UHF", "HF", "SATCOM", "DATA"],
+    "bands": {
+      "VHF": { "max_power_w": 100,  "max_coverage_area_m2": 4000000 },
+      "UHF": { "max_power_w": 100,  "max_coverage_area_m2": 3000000 }
+    },
+    "advertise_corridor": false,
+    "reports_allowed": ["SITREP", "SPOTREP", "LOGSTAT", "INTREP", "CASEVAC"]
+  },
+  "commander": {
+    "echelon": "BATTALION",
+    "subordinates_under": ["notional.ground.bct.company"],
+    "delegatable_verbs": ["move_to", "follow_route", "engage", "suppress"],
+    "request_support_types": ["FIRES", "ISR", "MEDEVAC", "LOGISTICS", "AIR"],
+    "max_delegation_ttl_turns": 6
+  },
+  "effect_parameter_ranges": {
+    "indirect_fire_arc": {
+      "range_m":          { "min": 1000, "max": 25000 },
+      "dispersion_ellipse_a_m": { "min": 5, "max": 200 },
+      "dispersion_ellipse_b_m": { "min": 5, "max": 200 },
+      "time_of_flight_s": { "min": 1,    "max": 60 }
+    },
+    "radar_fan": {
+      "sweep_arc_deg":    { "min": 10, "max": 360 },
+      "range_m":          { "min": 500,  "max": 50000 }
+    },
+    "ir_plume": {
+      "peak_intensity_w_per_sr": { "min": 1, "max": 4000 },
+      "decay_s":          { "min": 5,    "max": 240 }
+    },
+    "masint_cell": {
+      "polygon_area_m2":  { "min": 1000, "max": 4000000 },
+      "dwell_s":          { "min": 30,   "max": 3600 }
+    },
+    "keyhole_footprint": {
+      "polygon_area_m2":  { "min": 100,  "max": 100000 }
+    }
+  },
+  "entity_bindings": {
+    "type_subtype_refs": [
+      "notional.ground.bct.battalion",
+      "notional.ground.bct.hq.command-vehicle",
+      "notional.ground.bct.company"
+    ]
+  }
+}
+```
+
+### 8.2 Notional peer adversary (red) — `peer@1`
+
+A peer-level OpFor battalion. Includes `uncertainty` bands on what the
+blue side cannot precisely know about the adversary's reach.
+
+```json
+{
+  "profile_id": "00000000-rrrr-0001-0000-000000000001",
+  "version": 1,
+  "display_name": "Notional peer adversary — battalion",
+  "force_affiliation": "RED",
+  "officer_types_available": ["SENSOR", "EFFECTOR", "MOVER", "COMMUNICATOR", "COMMANDER"],
+  "action_verbs_available": [
+    "detect", "track", "classify", "lose_track",
+    "engage", "suppress", "destroy", "disable",
+    "move_to", "follow_route", "halt", "assume_posture",
+    "send", "relay", "jam", "report",
+    "issue_order", "request_support", "delegate", "escalate"
+  ],
+  "sensor": {
+    "modalities": {
+      "EO_IR":        { "max_range_m": 6000,  "min_classify_dwell_s": 4.0 },
+      "RADAR":        { "max_range_m": 60000, "min_classify_dwell_s": 1.5 },
+      "RF":           { "max_range_m": 90000, "min_classify_dwell_s": 2.0 }
+    },
+    "max_concurrent_tracks": 24,
+    "max_update_rate_hz": 4.0,
+    "default_track_lifetime_s": 150
+  },
+  "effector": {
+    "weapon_systems": [
+      {
+        "id": "notional.indirect.medium",
+        "delivery_mode": "INDIRECT",
+        "effective_range_m": 30000,
+        "ammo_remaining": 360,
+        "time_of_flight_s": 35,
+        "supported_verbs": ["engage", "suppress", "destroy"]
+      },
+      {
+        "id": "notional.ew.tactical",
+        "delivery_mode": "EW",
+        "effective_range_m": 50000,
+        "ammo_remaining": 99999,
+        "time_of_flight_s": 0,
+        "supported_verbs": ["disable"]
+      }
+    ],
+    "max_suppression_area_m2": 2500000,
+    "cyber_disable": false
+  },
+  "mover": {
+    "cruise_speed_mps": 13.9,
+    "max_speed_mps": 25.0,
+    "allowed_postures": ["HALTED", "MOUNTED", "DISMOUNTED", "DUG_IN", "ALERT"],
+    "posture_transitions": {
+      "HALTED":     ["MOUNTED", "ALERT"],
+      "MOUNTED":    ["HALTED", "ALERT"],
+      "DISMOUNTED": ["HALTED", "DUG_IN", "ALERT"],
+      "DUG_IN":     ["DISMOUNTED", "ALERT"],
+      "ALERT":      ["HALTED", "MOUNTED", "DISMOUNTED"]
+    }
+  },
+  "communicator": {
+    "channels": ["VHF", "UHF", "HF", "DATA"],
+    "bands": {
+      "VHF": { "max_power_w": 250, "max_coverage_area_m2": 8000000 },
+      "UHF": { "max_power_w": 250, "max_coverage_area_m2": 6000000 },
+      "L":   { "max_power_w": 1500, "max_coverage_area_m2": 4000000 }
+    },
+    "advertise_corridor": true,
+    "reports_allowed": ["SITREP", "SPOTREP", "INTREP"]
+  },
+  "commander": {
+    "echelon": "BATTALION",
+    "subordinates_under": ["notional.peer.company"],
+    "delegatable_verbs": ["move_to", "follow_route", "engage", "suppress", "jam"],
+    "request_support_types": ["FIRES", "ISR", "EW", "AIR"],
+    "max_delegation_ttl_turns": 4
+  },
+  "effect_parameter_ranges": {
+    "indirect_fire_arc": {
+      "range_m":          { "min": 1000, "max": 30000 },
+      "dispersion_ellipse_a_m": { "min": 8, "max": 300 },
+      "dispersion_ellipse_b_m": { "min": 8, "max": 300 },
+      "time_of_flight_s": { "min": 1,    "max": 90 }
+    },
+    "radar_fan": {
+      "sweep_arc_deg":    { "min": 5,   "max": 360 },
+      "range_m":          { "min": 500, "max": 60000 }
+    },
+    "jamming_circle": {
+      "radius_m":         { "min": 200, "max": 8000 },
+      "power_w":          { "min": 50,  "max": 1500 }
+    },
+    "ew_cone": {
+      "azimuth_deg":      { "min": 0,    "max": 359 },
+      "beamwidth_deg":    { "min": 5,    "max": 60 },
+      "effective_range_m": { "min": 1000, "max": 50000 }
+    },
+    "ir_plume": {
+      "peak_intensity_w_per_sr": { "min": 1, "max": 5000 },
+      "decay_s":          { "min": 5,    "max": 300 }
+    },
+    "uas_corridor": {
+      "altitude_band_lower_m": { "min": 100, "max": 6000 },
+      "altitude_band_upper_m": { "min": 100, "max": 8000 }
+    }
+  },
+  "uncertainty": {
+    "effector.weapon_systems[notional.indirect.medium].effective_range_m": { "band_pct": 0.20 },
+    "effector.weapon_systems[notional.ew.tactical].effective_range_m": { "band_pct": 0.30 },
+    "sensor.modalities.RADAR.max_range_m": { "band_pct": 0.25 },
+    "communicator.bands.L.max_power_w": { "band_lower": 500, "band_upper": 2000 }
+  },
+  "entity_bindings": {
+    "type_subtype_refs": [
+      "notional.peer.battalion",
+      "notional.peer.hq.command-vehicle",
+      "notional.peer.company"
+    ]
+  }
+}
+```
+
+---
+
+## 9. Open questions
+
+1. **Capability inheritance.** Two BCT companies under the same battalion
+   share most capabilities. v1 requires a separate profile per
+   `type_subtype_ref` if the capabilities differ at all; there's no
+   inheritance. Tracked for v2.
+2. **Live editing during scenario.** A frozen profile cannot be edited.
+   But the white cell may need to revoke a verb mid-scenario (e.g.,
+   "blue can no longer call `destroy`"). v1 handles this through the
+   override gateway (WS-303), not profile mutation. Confirm with the
+   white cell console design (WS-505).
+3. **Ammo persistence across turns.** `ammo_remaining` is a profile
+   field, but the *value* changes as the scenario progresses. v1 stores
+   the per-entity remaining ammo on the entity row (out-of-schema for
+   profile) and treats the profile field as the *initial* allocation.
+   This needs explicit wording before WS-202 implements.
+4. **Posture transition costs.** v1 has a flat adjacency list; doctrine
+   often has time/fuel costs per transition. Out of scope.
+5. **`null_profile` semantics for non-combatants.** A civilian vehicle
+   in the scenario binds to `null_profile`; should it still be visible
+   on EXCON consoles? Likely yes for white cell, no for blue/red. Decide
+   in WS-504 / WS-505.
+6. **Uncertainty path syntax.** Current syntax (dot + array-by-id)
+   handles every WS-105 reference but is informal. If more complex
+   structures appear in v2, adopting RFC 6901 JSON Pointer is the natural
+   upgrade.
+
+---
+
+## References
+
+- Officer interface contracts: [`officer-interfaces.md`](officer-interfaces.md) (WS-105)
+- Glossary — officer types, effect families, force affiliations: [`docs/glossary.md`](../glossary.md)
+- Neutral schema: [`docs/schema/entity-event.md`](entity-event.md) (WS-101)
+- Capability profile library (downstream): WS-107 (#11)
+- CZML validator (downstream): WS-202 (#14)
+- Officer interface tools (downstream): WS-402 (#22)
+- Effect artifact taxonomy (downstream): WS-108 (#12)
+- White cell console (downstream): WS-505 (#30)


### PR DESCRIPTION
## Summary

Defines the immutable-from-binding capability profile that drives agent decision-making (WS-403/404/405), CZML validator gating (WS-202), and officer-tool capability checks (WS-402).

Closes #10.

## Changes

- New file: `docs/schema/capability-profiles.md` (621 lines) — semantic spec with two fully-populated worked examples.
- New file: `docs/schema/capability-profile.schema.json` (331 lines) — JSON Schema draft 2020-12 contract.

## Highlights

- **Per-officer blocks named to match WS-105 path references.** Sensor / Effector / Mover / Communicator / Commander sub-blocks expose the exact paths WS-105 calls out (`profile.sensor.<modality>.max_range_m`, `profile.communicator.<band>.max_power_w`, `profile.mover.cruise_speed_mps`, etc.) so the validator and tools resolve them directly.
- **`effect_parameter_ranges` keyed by spatial-effect-family** (the nine families from the glossary). The validator (WS-202) intersects this with the template-side static range per WS-201 — matches the runbook's "intersect (template range, profile range)" wording exactly.
- **Versioning reframed.** Runbook says "immutable from turn 1"; I generalized to "immutable from first binding" (`frozen_at` flips from `null` to a UTC timestamp). Turn 1 is the common case, not a special case. Forks set `forked_from = {profile_id, version}` for AAR provenance.
- **Posture transition matrix is per-profile.** Resolves the open question WS-105 explicitly handed to WS-106 ("which postures can transition to which others"). Different platforms have different doctrinal transitions.
- **Uncertainty is RED-only.** Two band shapes: `band_pct` (relative ±) or `{band_lower, band_upper}` (absolute). Validator clamps to the upper bound on the wire so red can claim a band but cannot exceed the upper bound.
- **Six open questions logged** (capability inheritance, live editing, ammo persistence across turns, posture costs, `null_profile` semantics, uncertainty path syntax). Most are v2-bound.

## Definition of done check

- [x] All criteria from #10's Definition of done are satisfied: schema documented with two example profiles (US BCT blue, peer red).
- [x] Documentation updated (this is the deliverable).
- [x] Tests added or updated — N/A for v1 (no implementation), but **both worked examples validate against the JSON Schema using `jsonschema 4.26.0` Draft 2020-12** locally.
- [x] Banner present on any new visual surface — N/A (markdown / JSON; classification line at top of MD).

## Downstream impact

- Unblocks **WS-107** (#11) — notional profile library; four JSON profiles (`us-bct.json`, `peer.json`, `near-peer.json`, `hybrid-irregular.json`) author against this schema.
- Unblocks **WS-202** (#14) — the CZML validator's input contract (capability profile shape) is now stable.
- Unblocks **WS-402** (#22) — officer interface tools have a concrete `capability_profile.action_verbs_available` shape to gate against.
- Cross-references **WS-105** (#9) for the verb signatures and **WS-101** (#5) for `force_affiliation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)