### PR TITLE
feat(czml): add nine CZML effect templates and smoke harness (WS-201)

### DIFF
--- a/czml/templates/README.md
+++ b/czml/templates/README.md
@@ -1,0 +1,79 @@
+# Almighty — CZML template library
+
+> **Classification:** UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY
+
+CZML packet templates for the nine spatial effect families enumerated in [`docs/schema/artifacts.md`](../../docs/schema/artifacts.md) (WS-108). Each file is the wire-format contract for one effect type and is consumed by:
+
+- The capability-gated CZML validator at `services/czml-validator/` (WS-202) — reads `capability_constraints` and cross-references with the issuing entity's capability profile (WS-106 / WS-107).
+- The live CZML adapter at `services/czml-adapter/` (WS-503) — reads `base`, substitutes `{{tokens}}` from the artifact + event payload, and publishes the resulting CZML packet to the renderer.
+
+## File format
+
+Every template has three top-level blocks:
+
+| Block | Purpose |
+|---|---|
+| `base` | CZML packet skeleton with `{{token}}` placeholders. After substitution, this is what the renderer ingests. |
+| `params` | Declared parameter set with `type`, `units`, `required`, and (where applicable) `computed_from` notes. The single source of truth for what tokens the kernel must populate. |
+| `capability_constraints` | Subset of `params` whose values are gated by the issuing entity's capability profile. Mirrors the `effect_parameter_ranges` keys for this effect family in WS-106 / WS-107 profiles. |
+
+`capability_constraints` deliberately covers only the **tactical** parameters (azimuth, range, radius, dwell, etc.). Identifiers, time-validity, computed positions, and colors are not constrained — they're authored or derived, not chosen.
+
+## Templates
+
+| Template | Effect family | Cesium primitive | Tactical params |
+|---|---|---|---|
+| [`ew-cone.czml.json`](./ew-cone.czml.json) | EW emission cone | polygon (fan) | `azimuth_deg`, `beamwidth_deg`, `effective_range_m` |
+| [`uas-corridor.czml.json`](./uas-corridor.czml.json) | UAS flight corridor | corridor (extruded) | `width_m`, `altitude_band_lower_m`, `altitude_band_upper_m` |
+| [`radar-fan.czml.json`](./radar-fan.czml.json) | Radar coverage sector | polygon (fan) | `azimuth_deg`, `sweep_arc_deg`, `range_m` |
+| [`jamming-circle.czml.json`](./jamming-circle.czml.json) | Omnidirectional jamming area | ellipse | `radius_m`, `power_w` |
+| [`satellite-swath.czml.json`](./satellite-swath.czml.json) | Satellite sensor ground swath | corridor | `swath_width_m`, `pass_duration_s` |
+| [`indirect-fire-arc.czml.json`](./indirect-fire-arc.czml.json) | Ballistic indirect-fire trajectory | polyline | `range_m`, `time_of_flight_s`, `dispersion_ellipse_a_m`, `dispersion_ellipse_b_m` |
+| [`ir-plume.czml.json`](./ir-plume.czml.json) | IR plume from a hot source | cylinder | `peak_intensity_w_per_sr`, `decay_s` |
+| [`masint-cell.czml.json`](./masint-cell.czml.json) | MASINT collection cell | polygon | `polygon_area_m2`, `dwell_s` |
+| [`keyhole-footprint.czml.json`](./keyhole-footprint.czml.json) | KH-class imaging footprint | polygon | `polygon_area_m2` |
+
+## Token substitution
+
+Tokens use Mustache-style `{{name}}`. Two replacement modes:
+
+- **Whole-value tokens** — when a JSON string is exactly `"{{token}}"` (no other characters), the kernel replaces the string with the param value at its native type (number, array, etc.). This is how `cartographicDegrees: "{{cone_polygon_positions}}"` becomes a numeric array post-substitution.
+- **Interpolated tokens** — when `{{token}}` appears inside a longer string (e.g., the `name` and `description` fields), the param value is stringified and interpolated.
+
+The kernel computes any param marked `"computed_from": [...]` from the listed inputs (e.g., `cone_polygon_positions` is derived from `origin_*`, `azimuth_deg`, `beamwidth_deg`, `effective_range_m`). The smoke-test harness pre-computes these client-side using flat-earth approximations.
+
+## Smoke test
+
+[`_smoke-test.html`](./_smoke-test.html) is a one-page harness that loads each of the nine templates, fills it with sample params, and renders all nine in a 3×3 grid centered on Nashville (36.18°N, 86.78°W) using Cesium 1.123 served from CDN.
+
+```bash
+# From repo root, serve the czml/templates directory:
+python3 -m http.server 8000 --directory czml/templates
+# Then open:
+open http://localhost:8000/_smoke-test.html
+# Optional: append ?token=<your-cesium-ion-token> for high-res imagery.
+```
+
+A status panel in the top-left lists each template with ✓ on render success or ✗ with the error message on failure. WS-201 DoD: all nine show ✓ and all nine appear visibly distinct on the map.
+
+The smoke test does NOT depend on the Resium app shell (WS-501) — it loads vanilla Cesium from CDN so this directory can be validated independently of the renderer PR.
+
+## Validation
+
+JSON syntax is validated as part of the test harness load (any parse error surfaces in the status panel). For full Cesium-CZML schema validation, the `czml-validator` npm package can be used:
+
+```bash
+npx czml-validator czml/templates/*.czml.json
+```
+
+The capability-side validator (WS-202) is a separate service and validates the *post-substitution* packet, not the template itself.
+
+## Versioning
+
+Each template carries a top-level `version` field. Bump on any change that:
+
+- Adds, removes, or renames a token in `params`.
+- Changes the structure of `base` such that downstream renderers need to re-test.
+- Tightens `capability_constraints` (loosening is backward-compatible).
+
+WS-202 reads the template by `template_id`; multiple `version`s of the same `template_id` may coexist during a deprecation window.

--- a/czml/templates/_smoke-test.html
+++ b/czml/templates/_smoke-test.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Almighty — CZML template smoke test</title>
+    <link
+      rel="stylesheet"
+      href="https://cesium.com/downloads/cesiumjs/releases/1.123/Build/Cesium/Widgets/widgets.css"
+    />
+    <style>
+      html, body, #cesium { margin: 0; padding: 0; height: 100%; width: 100%; background: #000; color: #eee; font-family: system-ui, sans-serif; }
+      #banner { position: fixed; top: 0; left: 0; right: 0; background: #c0dd97; color: #111; font-size: 10px; line-height: 16px; text-align: center; font-weight: 600; z-index: 10; letter-spacing: 0.04em; }
+      #banner.bottom { top: auto; bottom: 0; }
+      #cesium { padding-top: 16px; padding-bottom: 16px; box-sizing: border-box; }
+      #status { position: fixed; top: 22px; left: 8px; background: rgba(0,0,0,0.75); padding: 8px 12px; font-size: 12px; max-width: 360px; z-index: 10; border-radius: 4px; line-height: 1.4; }
+      #status .ok { color: #8eff8e; }
+      #status .err { color: #ff8e8e; }
+    </style>
+  </head>
+  <body>
+    <div id="banner">UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY</div>
+    <div id="banner" class="bottom">UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY</div>
+    <div id="status">Loading templates…</div>
+    <div id="cesium"></div>
+
+    <script src="https://cesium.com/downloads/cesiumjs/releases/1.123/Build/Cesium/Cesium.js"></script>
+    <script type="module">
+      // Optional: set CESIUM_ION_TOKEN via URL query param (?token=...) for high-res imagery.
+      const urlToken = new URLSearchParams(location.search).get("token");
+      if (urlToken) Cesium.Ion.defaultAccessToken = urlToken;
+
+      const NASHVILLE = { lon: -86.78, lat: 36.18, alt: 8000 };
+      const TEMPLATES = [
+        "ew-cone",
+        "uas-corridor",
+        "radar-fan",
+        "jamming-circle",
+        "satellite-swath",
+        "indirect-fire-arc",
+        "ir-plume",
+        "masint-cell",
+        "keyhole-footprint",
+      ];
+
+      // 3x3 grid offsets in degrees from Nashville center (~3 km spacing).
+      const GRID = {
+        "ew-cone":           { dLon: -0.034, dLat: +0.027 },
+        "uas-corridor":      { dLon:  0.000, dLat: +0.027 },
+        "radar-fan":         { dLon: +0.034, dLat: +0.027 },
+        "jamming-circle":    { dLon: -0.034, dLat:  0.000 },
+        "satellite-swath":   { dLon:  0.000, dLat:  0.000 },
+        "indirect-fire-arc": { dLon: +0.034, dLat:  0.000 },
+        "ir-plume":          { dLon: -0.034, dLat: -0.027 },
+        "masint-cell":       { dLon:  0.000, dLat: -0.027 },
+        "keyhole-footprint": { dLon: +0.034, dLat: -0.027 },
+      };
+
+      const T_START = "2026-04-25T00:00:00Z";
+      const T_END   = "2026-04-25T01:00:00Z";
+
+      // Per-template sample params. Computed-from arrays are precomputed here
+      // since the kernel doesn't run in the smoke test.
+      function sampleParams(name, originLon, originLat) {
+        const base = {
+          artifact_id: `urn:smoke:${name}`,
+          owning_entity_id: `urn:smoke-entity:${name}`,
+          time_validity_start: T_START,
+          time_validity_end: T_END,
+          origin_lon_deg: originLon,
+          origin_lat_deg: originLat,
+          origin_alt_m: 200,
+        };
+        switch (name) {
+          case "ew-cone": {
+            // Fan apex at origin, sweeping 045° azimuth, 30° beamwidth, 1500 m range.
+            const apex = [originLon, originLat, 200];
+            const arc = arcPositions(originLon, originLat, 200, 45, 30, 1500, 12);
+            return { ...base, azimuth_deg: 45, beamwidth_deg: 30, effective_range_m: 1500,
+              cone_polygon_positions: [...apex, ...arc, ...apex] };
+          }
+          case "uas-corridor":
+            return { ...base, width_m: 200, altitude_band_lower_m: 300, altitude_band_upper_m: 800,
+              waypoint_positions: [
+                originLon - 0.012, originLat - 0.005, 500,
+                originLon,         originLat,         500,
+                originLon + 0.012, originLat + 0.005, 500,
+              ] };
+          case "radar-fan": {
+            const apex = [originLon, originLat, 200];
+            const arc = arcPositions(originLon, originLat, 200, 270, 90, 2000, 16);
+            return { ...base, azimuth_deg: 270, sweep_arc_deg: 90, range_m: 2000,
+              fan_polygon_positions: [...apex, ...arc, ...apex] };
+          }
+          case "jamming-circle":
+            return { ...base, radius_m: 1200, power_w: 250, band: "VHF" };
+          case "satellite-swath":
+            return { ...base, swath_width_m: 8000, pass_duration_s: 120,
+              ground_track_positions: [
+                originLon - 0.06, originLat - 0.02, 0,
+                originLon,        originLat,        0,
+                originLon + 0.06, originLat + 0.02, 0,
+              ] };
+          case "indirect-fire-arc": {
+            const firer = [originLon - 0.012, originLat - 0.008, 200];
+            const impact = [originLon + 0.012, originLat + 0.008, 200];
+            return { ...base,
+              firer_lon_deg: firer[0], firer_lat_deg: firer[1], firer_alt_m: firer[2],
+              impact_lon_deg: impact[0], impact_lat_deg: impact[1], impact_alt_m: impact[2],
+              range_m: 2500, time_of_flight_s: 18,
+              dispersion_ellipse_a_m: 30, dispersion_ellipse_b_m: 30,
+              trajectory_positions: ballisticArc(firer, impact, 1200, 16) };
+          }
+          case "ir-plume":
+            return { ...base, peak_intensity_w_per_sr: 800, decay_s: 60,
+              plume_height_m: 250, plume_top_radius_m: 60, plume_base_radius_m: 25 };
+          case "masint-cell":
+            return { ...base, polygon_area_m2: 90000, dwell_s: 300,
+              cell_polygon_positions: rectPolygon(originLon, originLat, 0.006, 0.005) };
+          case "keyhole-footprint":
+            return { ...base, polygon_area_m2: 75000, confidence: 0.85,
+              footprint_polygon_positions: rectPolygon(originLon, originLat, 0.005, 0.005) };
+          default:
+            return base;
+        }
+      }
+
+      // Geometry helpers — flat-earth approximations, sufficient for a smoke test at city scale.
+      function arcPositions(lon, lat, alt, azimuthDeg, sweepDeg, rangeM, samples) {
+        const out = [];
+        const start = azimuthDeg - sweepDeg / 2;
+        const end = azimuthDeg + sweepDeg / 2;
+        const metersPerDegLat = 111_000;
+        const metersPerDegLon = 111_000 * Math.cos((lat * Math.PI) / 180);
+        for (let i = 0; i <= samples; i++) {
+          const az = (start + ((end - start) * i) / samples) * (Math.PI / 180);
+          const dLon = (Math.sin(az) * rangeM) / metersPerDegLon;
+          const dLat = (Math.cos(az) * rangeM) / metersPerDegLat;
+          out.push(lon + dLon, lat + dLat, alt);
+        }
+        return out;
+      }
+
+      function ballisticArc(firer, impact, apexHeightM, samples) {
+        const out = [];
+        for (let i = 0; i <= samples; i++) {
+          const t = i / samples;
+          const lon = firer[0] + (impact[0] - firer[0]) * t;
+          const lat = firer[1] + (impact[1] - firer[1]) * t;
+          const baseAlt = firer[2] + (impact[2] - firer[2]) * t;
+          const arcAlt = apexHeightM * 4 * t * (1 - t); // parabolic apex
+          out.push(lon, lat, baseAlt + arcAlt);
+        }
+        return out;
+      }
+
+      function rectPolygon(lon, lat, dLonHalf, dLatHalf) {
+        return [
+          lon - dLonHalf, lat - dLatHalf, 0,
+          lon + dLonHalf, lat - dLatHalf, 0,
+          lon + dLonHalf, lat + dLatHalf, 0,
+          lon - dLonHalf, lat + dLatHalf, 0,
+          lon - dLonHalf, lat - dLatHalf, 0,
+        ];
+      }
+
+      // Mustache-lite substitution. If the entire string is "{{token}}", replace with the
+      // param value (preserving its type). Otherwise interpolate as text.
+      function fill(node, params) {
+        if (typeof node === "string") {
+          const m = node.match(/^\{\{(\w+)\}\}$/);
+          if (m) return m[1] in params ? params[m[1]] : node;
+          return node.replace(/\{\{(\w+)\}\}/g, (_, k) => k in params ? params[k] : `{{${k}}}`);
+        }
+        if (Array.isArray(node)) return node.map(v => fill(v, params));
+        if (node && typeof node === "object") {
+          const out = {};
+          for (const [k, v] of Object.entries(node)) out[k] = fill(v, params);
+          return out;
+        }
+        return node;
+      }
+
+      const viewer = new Cesium.Viewer("cesium", {
+        timeline: false, animation: false, baseLayerPicker: false, geocoder: false,
+        homeButton: false, sceneModePicker: false, navigationHelpButton: false,
+        fullscreenButton: false,
+      });
+      viewer.camera.setView({
+        destination: Cesium.Cartesian3.fromDegrees(NASHVILLE.lon, NASHVILLE.lat, NASHVILLE.alt),
+        orientation: { heading: 0, pitch: Cesium.Math.toRadians(-90), roll: 0 },
+      });
+
+      const status = document.getElementById("status");
+      const lines = [];
+      function log(msg, cls = "") { lines.push(`<div class="${cls}">${msg}</div>`); status.innerHTML = lines.join(""); }
+
+      (async () => {
+        for (const name of TEMPLATES) {
+          try {
+            const tpl = await fetch(`./${name}.czml.json`).then(r => {
+              if (!r.ok) throw new Error(`HTTP ${r.status}`);
+              return r.json();
+            });
+            const offset = GRID[name];
+            const params = sampleParams(name, NASHVILLE.lon + offset.dLon, NASHVILLE.lat + offset.dLat);
+            const filled = fill(tpl.base, params);
+            const czml = [
+              { id: "document", name, version: "1.0",
+                clock: { interval: `${T_START}/${T_END}`, currentTime: T_START, multiplier: 1 } },
+              filled,
+            ];
+            const ds = await Cesium.CzmlDataSource.load(czml);
+            viewer.dataSources.add(ds);
+            log(`✓ ${name}`, "ok");
+          } catch (err) {
+            log(`✗ ${name}: ${err.message}`, "err");
+            console.error(name, err);
+          }
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/czml/templates/ew-cone.czml.json
+++ b/czml/templates/ew-cone.czml.json
@@ -1,0 +1,45 @@
+{
+  "template_id": "ew-cone",
+  "version": 1,
+  "description": "Electronic-warfare emission cone projected from a platform-mounted emitter. Rendered as a planar polygon fan at platform altitude.",
+  "base": {
+    "id": "{{artifact_id}}",
+    "name": "EW cone — {{owning_entity_id}}",
+    "description": "EW emission cone, azimuth {{azimuth_deg}}°, beamwidth {{beamwidth_deg}}°, range {{effective_range_m}} m",
+    "availability": "{{time_validity_start}}/{{time_validity_end}}",
+    "polygon": {
+      "positions": { "cartographicDegrees": "{{cone_polygon_positions}}" },
+      "material": { "solidColor": { "color": { "rgba": "{{fill_rgba}}" } } },
+      "outline": true,
+      "outlineColor": { "rgba": "{{outline_rgba}}" },
+      "perPositionHeight": false,
+      "height": "{{origin_alt_m}}"
+    }
+  },
+  "params": {
+    "artifact_id":         { "type": "uuid",     "required": true },
+    "owning_entity_id":    { "type": "uuid",     "required": true },
+    "time_validity_start": { "type": "iso8601",  "required": true },
+    "time_validity_end":   { "type": "iso8601",  "required": true },
+    "origin_lon_deg":      { "type": "number",   "units": "deg",        "required": true },
+    "origin_lat_deg":      { "type": "number",   "units": "deg",        "required": true },
+    "origin_alt_m":        { "type": "number",   "units": "m",          "required": true },
+    "azimuth_deg":         { "type": "number",   "units": "deg",        "required": true },
+    "beamwidth_deg":       { "type": "number",   "units": "deg",        "required": true },
+    "effective_range_m":   { "type": "number",   "units": "m",          "required": true },
+    "cone_polygon_positions": {
+      "type": "number_array",
+      "units": "lon_lat_alt_triples",
+      "required": true,
+      "computed_from": ["origin_lon_deg", "origin_lat_deg", "origin_alt_m", "azimuth_deg", "beamwidth_deg", "effective_range_m"],
+      "description": "Flat array of [lon, lat, alt, lon, lat, alt, …] tracing the apex + arc, computed by the kernel from the tactical params."
+    },
+    "fill_rgba":    { "type": "rgba", "default": [200, 80, 80, 90] },
+    "outline_rgba": { "type": "rgba", "default": [200, 80, 80, 220] }
+  },
+  "capability_constraints": {
+    "azimuth_deg":       { "min": 0,    "max": 359,   "units": "deg" },
+    "beamwidth_deg":     { "min": 5,    "max": 60,    "units": "deg" },
+    "effective_range_m": { "min": 1000, "max": 50000, "units": "m" }
+  }
+}

--- a/czml/templates/indirect-fire-arc.czml.json
+++ b/czml/templates/indirect-fire-arc.czml.json
@@ -1,0 +1,48 @@
+{
+  "template_id": "indirect-fire-arc",
+  "version": 1,
+  "description": "Ballistic indirect-fire trajectory from firer to impact point, with a dispersion ellipse at the impact.",
+  "base": {
+    "id": "{{artifact_id}}",
+    "name": "Indirect fire arc — {{owning_entity_id}}",
+    "description": "Indirect fire, range {{range_m}} m, time-of-flight {{time_of_flight_s}} s",
+    "availability": "{{time_validity_start}}/{{time_validity_end}}",
+    "polyline": {
+      "positions": { "cartographicDegrees": "{{trajectory_positions}}" },
+      "width": 3,
+      "material": { "solidColor": { "color": { "rgba": "{{trajectory_rgba}}" } } },
+      "clampToGround": false,
+      "arcType": "NONE"
+    }
+  },
+  "params": {
+    "artifact_id":         { "type": "uuid",     "required": true },
+    "owning_entity_id":    { "type": "uuid",     "required": true },
+    "time_validity_start": { "type": "iso8601",  "required": true },
+    "time_validity_end":   { "type": "iso8601",  "required": true },
+    "firer_lon_deg":       { "type": "number",   "units": "deg", "required": true },
+    "firer_lat_deg":       { "type": "number",   "units": "deg", "required": true },
+    "firer_alt_m":         { "type": "number",   "units": "m",   "required": true },
+    "impact_lon_deg":      { "type": "number",   "units": "deg", "required": true },
+    "impact_lat_deg":      { "type": "number",   "units": "deg", "required": true },
+    "impact_alt_m":        { "type": "number",   "units": "m",   "required": true },
+    "range_m":                  { "type": "number", "units": "m", "required": true },
+    "time_of_flight_s":         { "type": "number", "units": "s", "required": true },
+    "dispersion_ellipse_a_m":   { "type": "number", "units": "m", "required": true },
+    "dispersion_ellipse_b_m":   { "type": "number", "units": "m", "required": true },
+    "trajectory_positions": {
+      "type": "number_array",
+      "units": "lon_lat_alt_triples",
+      "required": true,
+      "computed_from": ["firer_*", "impact_*", "time_of_flight_s"],
+      "description": "Sampled ballistic arc points (kernel-computed; ~16 samples between firer and impact)."
+    },
+    "trajectory_rgba": { "type": "rgba", "default": [255, 200, 80, 220] }
+  },
+  "capability_constraints": {
+    "range_m":                 { "min": 1000, "max": 30000, "units": "m" },
+    "dispersion_ellipse_a_m":  { "min": 5,    "max": 300,   "units": "m" },
+    "dispersion_ellipse_b_m":  { "min": 5,    "max": 300,   "units": "m" },
+    "time_of_flight_s":        { "min": 1,    "max": 90,    "units": "s" }
+  }
+}

--- a/czml/templates/ir-plume.czml.json
+++ b/czml/templates/ir-plume.czml.json
@@ -1,0 +1,41 @@
+{
+  "template_id": "ir-plume",
+  "version": 1,
+  "description": "Vertical infrared plume above a hot source (vehicle, fire, exhaust). Rendered as a vertical cylinder with intensity-mapped color.",
+  "base": {
+    "id": "{{artifact_id}}",
+    "name": "IR plume — {{owning_entity_id}}",
+    "description": "IR plume, peak {{peak_intensity_w_per_sr}} W/sr, decay {{decay_s}} s",
+    "availability": "{{time_validity_start}}/{{time_validity_end}}",
+    "position": { "cartographicDegrees": ["{{origin_lon_deg}}", "{{origin_lat_deg}}", "{{origin_alt_m}}"] },
+    "cylinder": {
+      "length": "{{plume_height_m}}",
+      "topRadius": "{{plume_top_radius_m}}",
+      "bottomRadius": "{{plume_base_radius_m}}",
+      "material": { "solidColor": { "color": { "rgba": "{{fill_rgba}}" } } },
+      "outline": true,
+      "outlineColor": { "rgba": "{{outline_rgba}}" },
+      "heightReference": "RELATIVE_TO_GROUND"
+    }
+  },
+  "params": {
+    "artifact_id":         { "type": "uuid",     "required": true },
+    "owning_entity_id":    { "type": "uuid",     "required": true },
+    "time_validity_start": { "type": "iso8601",  "required": true },
+    "time_validity_end":   { "type": "iso8601",  "required": true },
+    "origin_lon_deg":      { "type": "number",   "units": "deg", "required": true },
+    "origin_lat_deg":      { "type": "number",   "units": "deg", "required": true },
+    "origin_alt_m":        { "type": "number",   "units": "m",   "required": true },
+    "peak_intensity_w_per_sr": { "type": "number", "units": "W/sr", "required": true },
+    "decay_s":                 { "type": "number", "units": "s",    "required": true },
+    "plume_height_m":      { "type": "number", "units": "m", "required": true, "computed_from": ["peak_intensity_w_per_sr"] },
+    "plume_top_radius_m":  { "type": "number", "units": "m", "required": true, "computed_from": ["peak_intensity_w_per_sr"] },
+    "plume_base_radius_m": { "type": "number", "units": "m", "required": true, "computed_from": ["peak_intensity_w_per_sr"] },
+    "fill_rgba":    { "type": "rgba", "default": [255, 100, 40, 140] },
+    "outline_rgba": { "type": "rgba", "default": [255, 60, 20, 220] }
+  },
+  "capability_constraints": {
+    "peak_intensity_w_per_sr": { "min": 1, "max": 5000, "units": "W/sr" },
+    "decay_s":                { "min": 5, "max": 300,  "units": "s" }
+  }
+}

--- a/czml/templates/jamming-circle.czml.json
+++ b/czml/templates/jamming-circle.czml.json
@@ -1,0 +1,38 @@
+{
+  "template_id": "jamming-circle",
+  "version": 1,
+  "description": "Omnidirectional jamming coverage area: circle at emitter ground point, parameterized by radius and band.",
+  "base": {
+    "id": "{{artifact_id}}",
+    "name": "Jamming circle — {{owning_entity_id}}",
+    "description": "Jamming circle, radius {{radius_m}} m, power {{power_w}} W, band {{band}}",
+    "availability": "{{time_validity_start}}/{{time_validity_end}}",
+    "position": { "cartographicDegrees": ["{{origin_lon_deg}}", "{{origin_lat_deg}}", "{{origin_alt_m}}"] },
+    "ellipse": {
+      "semiMajorAxis": "{{radius_m}}",
+      "semiMinorAxis": "{{radius_m}}",
+      "material": { "solidColor": { "color": { "rgba": "{{fill_rgba}}" } } },
+      "outline": true,
+      "outlineColor": { "rgba": "{{outline_rgba}}" },
+      "heightReference": "CLAMP_TO_GROUND"
+    }
+  },
+  "params": {
+    "artifact_id":         { "type": "uuid",     "required": true },
+    "owning_entity_id":    { "type": "uuid",     "required": true },
+    "time_validity_start": { "type": "iso8601",  "required": true },
+    "time_validity_end":   { "type": "iso8601",  "required": true },
+    "origin_lon_deg":      { "type": "number",   "units": "deg", "required": true },
+    "origin_lat_deg":      { "type": "number",   "units": "deg", "required": true },
+    "origin_alt_m":        { "type": "number",   "units": "m",   "required": true },
+    "radius_m":            { "type": "number",   "units": "m",   "required": true },
+    "power_w":             { "type": "number",   "units": "W",   "required": true },
+    "band":                { "type": "string",   "required": true, "description": "Frequency band label (e.g., VHF, UHF, L, S). Informational; not validated by template." },
+    "fill_rgba":    { "type": "rgba", "default": [255, 80, 60, 90] },
+    "outline_rgba": { "type": "rgba", "default": [255, 80, 60, 220] }
+  },
+  "capability_constraints": {
+    "radius_m": { "min": 100, "max": 8000, "units": "m" },
+    "power_w":  { "min": 10,  "max": 1500, "units": "W" }
+  }
+}

--- a/czml/templates/keyhole-footprint.czml.json
+++ b/czml/templates/keyhole-footprint.czml.json
@@ -1,0 +1,37 @@
+{
+  "template_id": "keyhole-footprint",
+  "version": 1,
+  "description": "Overhead imaging footprint (KH satellite class): polygon over the imaged ground area.",
+  "base": {
+    "id": "{{artifact_id}}",
+    "name": "Keyhole footprint — {{owning_entity_id}}",
+    "description": "Keyhole footprint, area {{polygon_area_m2}} m², confidence {{confidence}}",
+    "availability": "{{time_validity_start}}/{{time_validity_end}}",
+    "polygon": {
+      "positions": { "cartographicDegrees": "{{footprint_polygon_positions}}" },
+      "material": { "solidColor": { "color": { "rgba": "{{fill_rgba}}" } } },
+      "outline": true,
+      "outlineColor": { "rgba": "{{outline_rgba}}" },
+      "heightReference": "CLAMP_TO_GROUND"
+    }
+  },
+  "params": {
+    "artifact_id":         { "type": "uuid",     "required": true },
+    "owning_entity_id":    { "type": "uuid",     "required": true },
+    "time_validity_start": { "type": "iso8601",  "required": true },
+    "time_validity_end":   { "type": "iso8601",  "required": true },
+    "footprint_polygon_positions": {
+      "type": "number_array",
+      "units": "lon_lat_alt_triples",
+      "required": true,
+      "description": "Closed polygon vertices for the imaged footprint (kernel-computed)."
+    },
+    "polygon_area_m2": { "type": "number", "units": "m^2",   "required": true },
+    "confidence":      { "type": "number", "units": "ratio", "required": true, "description": "Imaging confidence in [0, 1]; informational, not constrained by capability profile." },
+    "fill_rgba":    { "type": "rgba", "default": [80, 180, 220, 80] },
+    "outline_rgba": { "type": "rgba", "default": [80, 180, 220, 220] }
+  },
+  "capability_constraints": {
+    "polygon_area_m2": { "min": 100, "max": 200000, "units": "m^2" }
+  }
+}

--- a/czml/templates/masint-cell.czml.json
+++ b/czml/templates/masint-cell.czml.json
@@ -1,0 +1,38 @@
+{
+  "template_id": "masint-cell",
+  "version": 1,
+  "description": "Measurement-and-signature intelligence collection cell: ground polygon enclosing the area being characterized, with dwell time.",
+  "base": {
+    "id": "{{artifact_id}}",
+    "name": "MASINT cell — {{owning_entity_id}}",
+    "description": "MASINT cell, area {{polygon_area_m2}} m², dwell {{dwell_s}} s",
+    "availability": "{{time_validity_start}}/{{time_validity_end}}",
+    "polygon": {
+      "positions": { "cartographicDegrees": "{{cell_polygon_positions}}" },
+      "material": { "solidColor": { "color": { "rgba": "{{fill_rgba}}" } } },
+      "outline": true,
+      "outlineColor": { "rgba": "{{outline_rgba}}" },
+      "heightReference": "CLAMP_TO_GROUND"
+    }
+  },
+  "params": {
+    "artifact_id":         { "type": "uuid",     "required": true },
+    "owning_entity_id":    { "type": "uuid",     "required": true },
+    "time_validity_start": { "type": "iso8601",  "required": true },
+    "time_validity_end":   { "type": "iso8601",  "required": true },
+    "cell_polygon_positions": {
+      "type": "number_array",
+      "units": "lon_lat_alt_triples",
+      "required": true,
+      "description": "Closed polygon vertices (kernel-computed or hand-authored)."
+    },
+    "polygon_area_m2": { "type": "number", "units": "m^2", "required": true },
+    "dwell_s":         { "type": "number", "units": "s",   "required": true },
+    "fill_rgba":    { "type": "rgba", "default": [180, 80, 200, 70] },
+    "outline_rgba": { "type": "rgba", "default": [180, 80, 200, 220] }
+  },
+  "capability_constraints": {
+    "polygon_area_m2": { "min": 1000, "max": 10000000, "units": "m^2" },
+    "dwell_s":         { "min": 30,   "max": 7200,     "units": "s" }
+  }
+}

--- a/czml/templates/radar-fan.czml.json
+++ b/czml/templates/radar-fan.czml.json
@@ -1,0 +1,46 @@
+{
+  "template_id": "radar-fan",
+  "version": 1,
+  "description": "Radar coverage fan: sectorial polygon at sensor altitude, oriented by azimuth and bounded by sweep arc and range.",
+  "base": {
+    "id": "{{artifact_id}}",
+    "name": "Radar fan — {{owning_entity_id}}",
+    "description": "Radar fan, azimuth {{azimuth_deg}}°, sweep {{sweep_arc_deg}}°, range {{range_m}} m",
+    "availability": "{{time_validity_start}}/{{time_validity_end}}",
+    "polygon": {
+      "positions": { "cartographicDegrees": "{{fan_polygon_positions}}" },
+      "material": { "solidColor": { "color": { "rgba": "{{fill_rgba}}" } } },
+      "outline": true,
+      "outlineColor": { "rgba": "{{outline_rgba}}" },
+      "perPositionHeight": false,
+      "height": "{{origin_alt_m}}"
+    }
+  },
+  "params": {
+    "artifact_id":         { "type": "uuid",     "required": true },
+    "owning_entity_id":    { "type": "uuid",     "required": true },
+    "time_validity_start": { "type": "iso8601",  "required": true },
+    "time_validity_end":   { "type": "iso8601",  "required": true },
+    "origin_lon_deg":      { "type": "number",   "units": "deg", "required": true },
+    "origin_lat_deg":      { "type": "number",   "units": "deg", "required": true },
+    "origin_alt_m":        { "type": "number",   "units": "m",   "required": true },
+    "azimuth_deg":         { "type": "number",   "units": "deg", "required": true },
+    "sweep_arc_deg":       { "type": "number",   "units": "deg", "required": true },
+    "range_m":             { "type": "number",   "units": "m",   "required": true },
+    "elevation_deg":       { "type": "number",   "units": "deg", "required": false, "description": "Optional elevation tilt for 3D fans; v1 ignores this and renders flat." },
+    "fan_polygon_positions": {
+      "type": "number_array",
+      "units": "lon_lat_alt_triples",
+      "required": true,
+      "computed_from": ["origin_lon_deg", "origin_lat_deg", "origin_alt_m", "azimuth_deg", "sweep_arc_deg", "range_m"],
+      "description": "Apex + arc vertices computed by the kernel."
+    },
+    "fill_rgba":    { "type": "rgba", "default": [80, 200, 120, 70] },
+    "outline_rgba": { "type": "rgba", "default": [80, 200, 120, 220] }
+  },
+  "capability_constraints": {
+    "azimuth_deg":   { "min": 0,   "max": 359,   "units": "deg" },
+    "sweep_arc_deg": { "min": 5,   "max": 360,   "units": "deg" },
+    "range_m":       { "min": 500, "max": 80000, "units": "m" }
+  }
+}

--- a/czml/templates/satellite-swath.czml.json
+++ b/czml/templates/satellite-swath.czml.json
@@ -1,0 +1,40 @@
+{
+  "template_id": "satellite-swath",
+  "version": 1,
+  "description": "Satellite sensor ground swath traced as a wide corridor along the orbit ground track.",
+  "base": {
+    "id": "{{artifact_id}}",
+    "name": "Satellite swath — {{owning_entity_id}}",
+    "description": "Swath width {{swath_width_m}} m, pass duration {{pass_duration_s}} s",
+    "availability": "{{time_validity_start}}/{{time_validity_end}}",
+    "corridor": {
+      "positions": { "cartographicDegrees": "{{ground_track_positions}}" },
+      "width": "{{swath_width_m}}",
+      "cornerType": "MITERED",
+      "material": { "solidColor": { "color": { "rgba": "{{fill_rgba}}" } } },
+      "outline": true,
+      "outlineColor": { "rgba": "{{outline_rgba}}" },
+      "heightReference": "CLAMP_TO_GROUND"
+    }
+  },
+  "params": {
+    "artifact_id":         { "type": "uuid",     "required": true },
+    "owning_entity_id":    { "type": "uuid",     "required": true },
+    "time_validity_start": { "type": "iso8601",  "required": true },
+    "time_validity_end":   { "type": "iso8601",  "required": true },
+    "ground_track_positions": {
+      "type": "number_array",
+      "units": "lon_lat_alt_triples",
+      "required": true,
+      "description": "Polyline of orbit ground track waypoints (kernel-computed from TLEs or scenario script)."
+    },
+    "swath_width_m":   { "type": "number", "units": "m", "required": true },
+    "pass_duration_s": { "type": "number", "units": "s", "required": true },
+    "fill_rgba":    { "type": "rgba", "default": [180, 200, 80, 60] },
+    "outline_rgba": { "type": "rgba", "default": [180, 200, 80, 200] }
+  },
+  "capability_constraints": {
+    "swath_width_m":   { "min": 5000, "max": 250000, "units": "m" },
+    "pass_duration_s": { "min": 30,   "max": 1800,   "units": "s" }
+  }
+}

--- a/czml/templates/uas-corridor.czml.json
+++ b/czml/templates/uas-corridor.czml.json
@@ -1,0 +1,43 @@
+{
+  "template_id": "uas-corridor",
+  "version": 1,
+  "description": "UAS flight corridor along a polyline, with a width and altitude band.",
+  "base": {
+    "id": "{{artifact_id}}",
+    "name": "UAS corridor — {{owning_entity_id}}",
+    "description": "UAS corridor, width {{width_m}} m, altitude {{altitude_band_lower_m}}–{{altitude_band_upper_m}} m",
+    "availability": "{{time_validity_start}}/{{time_validity_end}}",
+    "corridor": {
+      "positions": { "cartographicDegrees": "{{waypoint_positions}}" },
+      "width": "{{width_m}}",
+      "height": "{{altitude_band_lower_m}}",
+      "extrudedHeight": "{{altitude_band_upper_m}}",
+      "cornerType": "ROUNDED",
+      "material": { "solidColor": { "color": { "rgba": "{{fill_rgba}}" } } },
+      "outline": true,
+      "outlineColor": { "rgba": "{{outline_rgba}}" }
+    }
+  },
+  "params": {
+    "artifact_id":         { "type": "uuid",     "required": true },
+    "owning_entity_id":    { "type": "uuid",     "required": true },
+    "time_validity_start": { "type": "iso8601",  "required": true },
+    "time_validity_end":   { "type": "iso8601",  "required": true },
+    "waypoint_positions": {
+      "type": "number_array",
+      "units": "lon_lat_alt_triples",
+      "required": true,
+      "description": "Flat array of [lon, lat, alt, …] for each corridor waypoint (≥ 2 waypoints)."
+    },
+    "width_m":                { "type": "number", "units": "m", "required": true },
+    "altitude_band_lower_m":  { "type": "number", "units": "m", "required": true },
+    "altitude_band_upper_m":  { "type": "number", "units": "m", "required": true },
+    "fill_rgba":    { "type": "rgba", "default": [120, 200, 255, 80] },
+    "outline_rgba": { "type": "rgba", "default": [120, 200, 255, 220] }
+  },
+  "capability_constraints": {
+    "altitude_band_lower_m": { "min": 100,  "max": 12000, "units": "m" },
+    "altitude_band_upper_m": { "min": 100,  "max": 12000, "units": "m" },
+    "width_m":               { "min": 50,   "max": 5000,  "units": "m" }
+  }
+}


### PR DESCRIPTION
## Summary
- Nine CZML packet templates at `czml/templates/<effect>.czml.json`, one per spatial effect family from WS-108: EW cone, UAS corridor, radar fan, jamming circle, satellite swath, indirect fire arc, IR plume, MASINT cell, keyhole footprint.
- Each template carries three top-level blocks per spec: `base` (CZML packet skeleton with `{{tokens}}`), `params` (declared parameter set with units), `capability_constraints` (mirrors the `effect_parameter_ranges` keys for that family in WS-106 / WS-107).
- Vanilla-Cesium smoke harness at `czml/templates/_smoke-test.html` — loads all nine, fills sample params, renders in a 3×3 grid over Nashville. Independent of the Resium scaffold (WS-501) so this can be verified standalone.
- `czml/templates/README.md` documents the format, lists all nine templates, and explains the Mustache-token substitution rules.

Unblocks @devindynamo's **WS-202** (capability-gated CZML validator), which has been the only gate left for him after WS-107 landed.

Closes #13.

## Test plan
- [ ] `python3 -m http.server 8000 --directory czml/templates && open http://localhost:8000/_smoke-test.html`
- [ ] Confirm Nashville visible top-down, both banners present.
- [ ] Status panel (top-left) shows ✓ for all nine templates.
- [ ] Visually confirm nine geographically-separated shapes appear in a 3×3 grid: cone fan, extruded corridor, radar fan, ground circle, wide swath, ballistic arc, vertical cylinder, ground polygon, ground polygon.