### PR TITLE
feat(czml): add Nashville effect catalog + standalone viewer (WS-203)

### DIFF
--- a/czml/demos/README.md
+++ b/czml/demos/README.md
@@ -1,0 +1,49 @@
+# Almighty — CZML demo files
+
+> **Classification:** UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY
+
+Hand-authored static CZML files for visual verification of the WS-201 effect templates and for stakeholder demos. These files require **no kernel involvement** — they're pure static CZML, loaded directly into Resium / Cesium.
+
+## Files
+
+| File | Ticket | Purpose |
+|---|---|---|
+| [`effect-catalog.czml`](./effect-catalog.czml) | WS-203 | Visual regression catalog: 9 effect families laid out in a 3×3 grid centered on Nashville, staggered in time across one hour so each is individually inspectable on the timeline. |
+| `nashville-vignette.czml` | WS-204 (planned) | Scripted ~10-minute Cumberland River crossing slice. Not yet authored. |
+
+## Viewing
+
+A standalone vanilla-Cesium viewer is included at [`_view.html`](./_view.html). Serve this directory with any static server and open the viewer in a browser — no Vite, Resium, or build step required.
+
+```bash
+# From repo root:
+python3 -m http.server 8000 --directory czml/demos
+# Then open:
+open http://localhost:8000/_view.html
+# Pick a different file via query param:
+open "http://localhost:8000/_view.html?file=nashville-vignette.czml"
+# High-res imagery:
+open "http://localhost:8000/_view.html?token=YOUR_VITE_CESIUM_ION_TOKEN_VALUE"
+```
+
+The viewer enables Cesium's timeline + animation widgets so you can scrub through staggered activations.
+
+## Layout convention (effect-catalog.czml)
+
+3×3 grid centered on Nashville (36.18°N, 86.78°W) with ~3 km cell spacing:
+
+```
+  NW: ew-cone        |  N: uas-corridor    |  NE: radar-fan
+  W:  jamming-circle |  C: satellite-swath |  E:  indirect-fire-arc
+  SW: ir-plume       |  S: masint-cell     |  SE: keyhole-footprint
+```
+
+Each effect uses notional but visible-scale tactical parameters (1–4 km extents). At full-tactical scale (e.g., a 200 km satellite swath), most effects would dominate the entire view; values were tuned to keep the catalog's visual purpose (one effect per cell, identifiable at a glance) intact.
+
+## Time
+
+Catalog availability spans `2026-04-25T00:00:00Z` → `2026-04-25T01:00:00Z`. Effects activate every ~6m 40s in grid order (NW → SE) and remain visible until the end so the scrubber can land on any subset.
+
+## Banner
+
+The unclassified banner is the renderer's responsibility (WS-501 / app-shell). The standalone viewer here renders it on top + bottom of the canvas so the file can be verified in isolation; production use inside the Resium scaffold inherits the banner from `App.tsx`.

--- a/czml/demos/_view.html
+++ b/czml/demos/_view.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Almighty — CZML demo viewer</title>
+    <link
+      rel="stylesheet"
+      href="https://cesium.com/downloads/cesiumjs/releases/1.123/Build/Cesium/Widgets/widgets.css"
+    />
+    <style>
+      html, body, #cesium { margin: 0; padding: 0; height: 100%; width: 100%; background: #000; color: #eee; font-family: system-ui, sans-serif; }
+      #banner { position: fixed; top: 0; left: 0; right: 0; background: #c0dd97; color: #111; font-size: 10px; line-height: 16px; text-align: center; font-weight: 600; z-index: 10; letter-spacing: 0.04em; }
+      #banner.bottom { top: auto; bottom: 0; }
+      #cesium { padding-top: 16px; padding-bottom: 16px; box-sizing: border-box; }
+      #status { position: fixed; top: 22px; left: 8px; background: rgba(0,0,0,0.75); padding: 8px 12px; font-size: 12px; max-width: 360px; z-index: 10; border-radius: 4px; line-height: 1.4; }
+      .ok  { color: #8eff8e; }
+      .err { color: #ff8e8e; }
+    </style>
+  </head>
+  <body>
+    <div id="banner">UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY</div>
+    <div id="banner" class="bottom">UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY</div>
+    <div id="status">Loading…</div>
+    <div id="cesium"></div>
+
+    <script src="https://cesium.com/downloads/cesiumjs/releases/1.123/Build/Cesium/Cesium.js"></script>
+    <script type="module">
+      // Pick the demo file via ?file=<name.czml> (default: effect-catalog.czml).
+      // Optional: ?token=<cesium-ion-token> for high-res imagery.
+      const params = new URLSearchParams(location.search);
+      const fileName = params.get("file") || "effect-catalog.czml";
+      const token = params.get("token");
+      if (token) Cesium.Ion.defaultAccessToken = token;
+
+      const status = document.getElementById("status");
+      const log = (msg, cls = "") => {
+        status.innerHTML = `<div class="${cls}">${msg}</div>`;
+      };
+
+      const viewer = new Cesium.Viewer("cesium", {
+        timeline: true, animation: true, baseLayerPicker: false, geocoder: false,
+        homeButton: false, sceneModePicker: false, navigationHelpButton: false,
+        fullscreenButton: false,
+      });
+      viewer.camera.setView({
+        destination: Cesium.Cartesian3.fromDegrees(-86.78, 36.18, 12000),
+        orientation: { heading: 0, pitch: Cesium.Math.toRadians(-90), roll: 0 },
+      });
+
+      try {
+        const ds = await Cesium.CzmlDataSource.load(`./${fileName}`);
+        await viewer.dataSources.add(ds);
+        log(`✓ loaded ${fileName} (${ds.entities.values.length} entities)`, "ok");
+      } catch (err) {
+        log(`✗ ${fileName}: ${err.message}`, "err");
+        console.error(err);
+      }
+    </script>
+  </body>
+</html>

--- a/czml/demos/effect-catalog.czml
+++ b/czml/demos/effect-catalog.czml
@@ -1,0 +1,158 @@
+[
+  {
+    "id": "document",
+    "name": "Almighty effect catalog (Nashville)",
+    "version": "1.0",
+    "description": "WS-203 — visual regression catalog of the nine WS-201 effect templates, hand-authored as static CZML. Effects laid out in a 3x3 grid centered on Nashville (~3 km cell spacing) and staggered in time across one hour so the timeline scrubber lands on each one individually. UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY (banner is the renderer's responsibility, WS-501).",
+    "clock": {
+      "interval": "2026-04-25T00:00:00Z/2026-04-25T01:00:00Z",
+      "currentTime": "2026-04-25T00:00:00Z",
+      "multiplier": 60,
+      "range": "LOOP_STOP",
+      "step": "SYSTEM_CLOCK_MULTIPLIER"
+    }
+  },
+  {
+    "id": "ew-cone-demo",
+    "name": "EW cone — demo",
+    "description": "Electronic-warfare emission cone. Apex at NW grid cell, azimuth 045°, beamwidth 30°, range 3 km.",
+    "availability": "2026-04-25T00:00:00Z/2026-04-25T01:00:00Z",
+    "polygon": {
+      "positions": {
+        "cartographicDegrees": [-86.814, 36.207, 200, -86.79726, 36.23041, 200, -86.79576, 36.22967, 200, -86.79432, 36.22887, 200, -86.79293, 36.228, 200, -86.79159, 36.22708, 200, -86.79032, 36.22611, 200, -86.78912, 36.22508, 200, -86.78798, 36.22401, 200, -86.78691, 36.22289, 200, -86.78592, 36.22172, 200, -86.785, 36.22051, 200, -86.814, 36.207, 200]
+      },
+      "material": { "solidColor": { "color": { "rgba": [200, 80, 80, 90] } } },
+      "outline": true,
+      "outlineColor": { "rgba": [200, 80, 80, 220] },
+      "perPositionHeight": false,
+      "height": 200
+    }
+  },
+  {
+    "id": "uas-corridor-demo",
+    "name": "UAS corridor — demo",
+    "description": "UAS flight corridor running NE at the N grid cell, 200 m wide, altitude band 300–800 m.",
+    "availability": "2026-04-25T00:06:40Z/2026-04-25T01:00:00Z",
+    "corridor": {
+      "positions": {
+        "cartographicDegrees": [-86.798, 36.199, 500, -86.78, 36.207, 500, -86.762, 36.215, 500]
+      },
+      "width": 200,
+      "height": 300,
+      "extrudedHeight": 800,
+      "cornerType": "ROUNDED",
+      "material": { "solidColor": { "color": { "rgba": [120, 200, 255, 80] } } },
+      "outline": true,
+      "outlineColor": { "rgba": [120, 200, 255, 220] }
+    }
+  },
+  {
+    "id": "radar-fan-demo",
+    "name": "Radar fan — demo",
+    "description": "Radar coverage fan at NE grid cell, azimuth 270° (west), 90° sweep, 3.5 km range.",
+    "availability": "2026-04-25T00:13:20Z/2026-04-25T01:00:00Z",
+    "polygon": {
+      "positions": {
+        "cartographicDegrees": [-86.746, 36.207, 200, -86.77362, 36.1847, 200, -86.7776, 36.18847, 200, -86.78081, 36.19268, 200, -86.78315, 36.19726, 200, -86.78458, 36.20207, 200, -86.78506, 36.207, 200, -86.78458, 36.21193, 200, -86.78315, 36.21674, 200, -86.78081, 36.22132, 200, -86.7776, 36.22553, 200, -86.77362, 36.2293, 200, -86.746, 36.207, 200]
+      },
+      "material": { "solidColor": { "color": { "rgba": [80, 200, 120, 70] } } },
+      "outline": true,
+      "outlineColor": { "rgba": [80, 200, 120, 220] },
+      "perPositionHeight": false,
+      "height": 200
+    }
+  },
+  {
+    "id": "jamming-circle-demo",
+    "name": "Jamming circle — demo",
+    "description": "Omnidirectional jamming coverage at W grid cell, radius 1.5 km, VHF band.",
+    "availability": "2026-04-25T00:20:00Z/2026-04-25T01:00:00Z",
+    "position": { "cartographicDegrees": [-86.814, 36.18, 0] },
+    "ellipse": {
+      "semiMajorAxis": 1500,
+      "semiMinorAxis": 1500,
+      "material": { "solidColor": { "color": { "rgba": [255, 80, 60, 90] } } },
+      "outline": true,
+      "outlineColor": { "rgba": [255, 80, 60, 220] },
+      "heightReference": "CLAMP_TO_GROUND"
+    }
+  },
+  {
+    "id": "satellite-swath-demo",
+    "name": "Satellite swath — demo",
+    "description": "Satellite ground swath crossing the center cell, 8 km wide along a NW→SE pass.",
+    "availability": "2026-04-25T00:26:40Z/2026-04-25T01:00:00Z",
+    "corridor": {
+      "positions": {
+        "cartographicDegrees": [-86.86, 36.15, 0, -86.78, 36.18, 0, -86.7, 36.21, 0]
+      },
+      "width": 8000,
+      "cornerType": "MITERED",
+      "material": { "solidColor": { "color": { "rgba": [180, 200, 80, 60] } } },
+      "outline": true,
+      "outlineColor": { "rgba": [180, 200, 80, 200] },
+      "heightReference": "CLAMP_TO_GROUND"
+    }
+  },
+  {
+    "id": "indirect-fire-arc-demo",
+    "name": "Indirect fire arc — demo",
+    "description": "Ballistic indirect-fire trajectory at E grid cell, range ~3 km, parabolic apex 1.5 km.",
+    "availability": "2026-04-25T00:33:20Z/2026-04-25T01:00:00Z",
+    "polyline": {
+      "positions": {
+        "cartographicDegrees": [-86.76, 36.169, 200.0, -86.75767, 36.17083, 658.3, -86.75533, 36.17267, 1033.3, -86.753, 36.1745, 1325.0, -86.75067, 36.17633, 1533.3, -86.74833, 36.17817, 1658.3, -86.746, 36.18, 1700.0, -86.74367, 36.18183, 1658.3, -86.74133, 36.18367, 1533.3, -86.739, 36.1855, 1325.0, -86.73667, 36.18733, 1033.3, -86.73433, 36.18917, 658.3, -86.732, 36.191, 200.0]
+      },
+      "width": 4,
+      "material": { "solidColor": { "color": { "rgba": [255, 200, 80, 230] } } },
+      "clampToGround": false,
+      "arcType": "NONE"
+    }
+  },
+  {
+    "id": "ir-plume-demo",
+    "name": "IR plume — demo",
+    "description": "Vertical IR plume at SW grid cell, 300 m tall, peak intensity 800 W/sr.",
+    "availability": "2026-04-25T00:40:00Z/2026-04-25T01:00:00Z",
+    "position": { "cartographicDegrees": [-86.814, 36.153, 200] },
+    "cylinder": {
+      "length": 300,
+      "topRadius": 60,
+      "bottomRadius": 25,
+      "material": { "solidColor": { "color": { "rgba": [255, 100, 40, 160] } } },
+      "outline": true,
+      "outlineColor": { "rgba": [255, 60, 20, 220] },
+      "heightReference": "RELATIVE_TO_GROUND"
+    }
+  },
+  {
+    "id": "masint-cell-demo",
+    "name": "MASINT cell — demo",
+    "description": "MASINT collection cell at S grid cell, ~1.6 × 1.5 km rectangular polygon.",
+    "availability": "2026-04-25T00:46:40Z/2026-04-25T01:00:00Z",
+    "polygon": {
+      "positions": {
+        "cartographicDegrees": [-86.788, 36.146, 0, -86.772, 36.146, 0, -86.772, 36.16, 0, -86.788, 36.16, 0, -86.788, 36.146, 0]
+      },
+      "material": { "solidColor": { "color": { "rgba": [180, 80, 200, 70] } } },
+      "outline": true,
+      "outlineColor": { "rgba": [180, 80, 200, 220] },
+      "heightReference": "CLAMP_TO_GROUND"
+    }
+  },
+  {
+    "id": "keyhole-footprint-demo",
+    "name": "Keyhole footprint — demo",
+    "description": "KH-class imaging footprint at SE grid cell, ~1.2 × 1.1 km rectangular polygon.",
+    "availability": "2026-04-25T00:53:20Z/2026-04-25T01:00:00Z",
+    "polygon": {
+      "positions": {
+        "cartographicDegrees": [-86.752, 36.148, 0, -86.74, 36.148, 0, -86.74, 36.158, 0, -86.752, 36.158, 0, -86.752, 36.148, 0]
+      },
+      "material": { "solidColor": { "color": { "rgba": [80, 180, 220, 80] } } },
+      "outline": true,
+      "outlineColor": { "rgba": [80, 180, 220, 220] },
+      "heightReference": "CLAMP_TO_GROUND"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- `czml/demos/effect-catalog.czml` — single static CZML packet array, 9 effect families in a 3×3 grid centered on Nashville (~3 km cell spacing). Pure static CZML; no kernel, no template substitution, loads directly into Cesium.
- Each effect has staggered `availability` across one hour so the timeline scrubber lands on each individually (NW → SE order, ~6m 40s apart, all running until end).
- `czml/demos/_view.html` — vanilla-Cesium standalone viewer (no Vite / Resium dep) with timeline + animation enabled, so this directory is verifiable independent of WS-501.
- `czml/demos/README.md` — documents grid layout, time stagger, banner ownership, and viewer usage.

Spec note: WS-203 is officially blocked by WS-201 (#13, in PR #48). The two PRs are independent at the file level — WS-203 doesn't reference WS-201's templates, only the same effect taxonomy from WS-108 (already merged). Mergeable in either order.

Closes #15.

## Test plan
- [ ] `python3 -m http.server 8000 --directory czml/demos && open http://localhost:8000/_view.html`
- [ ] Confirm Nashville visible top-down with both banners.
- [ ] Status panel top-left shows `✓ loaded effect-catalog.czml (9 entities)`.
- [ ] Scrub the timeline (or hit play): effects appear in NW → SE grid order, accumulating.
- [ ] Visually distinct: 2 fans, 1 corridor, 1 ground circle, 1 wide swath, 1 ballistic arc, 1 vertical cylinder, 2 ground polygons.