### PR TITLE
feat(renderer): static CZML loader + dev toggle (WS-502)

### DIFF
--- a/web/renderer/.gitignore
+++ b/web/renderer/.gitignore
@@ -5,3 +5,4 @@ dist-ssr
 .env
 .env.local
 .vite
+*.tsbuildinfo

--- a/web/renderer/package.json
+++ b/web/renderer/package.json
@@ -22,7 +22,8 @@
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.6.3",
     "vite": "^6.0.0",
-    "vite-plugin-cesium": "^1.2.23"
+    "vite-plugin-cesium": "^1.2.23",
+    "vite-plugin-static-copy": "^2.2.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": ["esbuild", "protobufjs"]

--- a/web/renderer/pnpm-lock.yaml
+++ b/web/renderer/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       vite-plugin-cesium:
         specifier: ^1.2.23
         version: 1.2.23(cesium@1.140.0)(rollup@4.60.2)(vite@6.4.2(@types/node@25.6.0))
+      vite-plugin-static-copy:
+        specifier: ^2.2.0
+        version: 2.3.2(vite@6.4.2(@types/node@25.6.0))
 
 packages:
 
@@ -311,6 +314,18 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -539,6 +554,10 @@ packages:
     resolution: {integrity: sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==}
     engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=18.0.0'}
 
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
   at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
@@ -552,8 +571,16 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
   bitmap-sdf@1.0.4:
     resolution: {integrity: sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -566,6 +593,10 @@ packages:
   cesium@1.140.0:
     resolution: {integrity: sha512-3RvW0rvZWuXiS6regtNE5u9vt0uXohgpsRBIo6Qc922IIIamkitYiEdr4fg+u4qX4EoK9xS3BosCza7iPOExEQ==}
     engines: {node: '>=20.19.0'}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -639,6 +670,13 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -648,9 +686,17 @@ packages:
       picomatch:
         optional: true
 
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fs-extra@11.3.4:
+    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+    engines: {node: '>=14.14'}
 
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -665,6 +711,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -677,6 +727,22 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -723,11 +789,19 @@ packages:
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   mersenne-twister@1.1.0:
     resolution: {integrity: sha512-mUYWsMKNrm4lfygPkL3OfGzOPTR2DBlTkBNHM//F6hGp8cLThY897crAlk3/Jo17LEOOjQUrNAx6DvgO77QJkA==}
 
   meshoptimizer@1.1.1:
     resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -748,12 +822,20 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   nosleep.js@0.12.0:
     resolution: {integrity: sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
+
+  p-map@7.0.4:
+    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
+    engines: {node: '>=18'}
 
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
@@ -780,6 +862,9 @@ packages:
   protobufjs@8.0.1:
     resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quickselect@3.0.0:
     resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
@@ -817,6 +902,10 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
   resium@1.21.0:
     resolution: {integrity: sha512-fxP43kQKXQeDkZ2gwHN08vFvsaKefJ21NeeJMuAeYl/3OmspRpZx4BcfwbfvhsQhLMMmXQreHInfwO8RUoh81A==}
     engines: {node: '>=20.19.0'}
@@ -824,6 +913,10 @@ packages:
       cesium: 1.x
       react: '>=18.2.0'
       react-dom: '>=18.2.0'
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rollup-plugin-external-globals@0.6.1:
     resolution: {integrity: sha512-mlp3KNa5sE4Sp9UUR2rjBrxjG79OyZAh/QC18RHIjM+iYkbBwNXSo8DHRMZWtzJTrH8GxQ+SJvCTN3i14uMXIA==}
@@ -834,6 +927,9 @@ packages:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -868,6 +964,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -906,6 +1006,12 @@ packages:
     peerDependencies:
       cesium: ^1.95.0
       vite: '>=2.7.1'
+
+  vite-plugin-static-copy@2.3.2:
+    resolution: {integrity: sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -1192,6 +1298,18 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -1358,6 +1476,11 @@ snapshots:
 
   '@zip.js/zip.js@2.8.26': {}
 
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
   at-least-node@1.0.0: {}
 
   autolinker@4.1.5:
@@ -1366,7 +1489,13 @@ snapshots:
 
   baseline-browser-mapping@2.10.22: {}
 
+  binary-extensions@2.3.0: {}
+
   bitmap-sdf@1.0.4: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
 
   browserslist@4.28.2:
     dependencies:
@@ -1382,6 +1511,18 @@ snapshots:
     dependencies:
       '@cesium/engine': 24.0.0
       '@cesium/widgets': 14.5.0
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   commander@2.20.3: {}
 
@@ -1452,11 +1593,33 @@ snapshots:
 
   etag@1.8.1: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
   fresh@0.5.2: {}
+
+  fs-extra@11.3.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
 
   fs-extra@9.1.0:
     dependencies:
@@ -1469,6 +1632,10 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   graceful-fs@4.2.11: {}
 
@@ -1483,6 +1650,18 @@ snapshots:
       toidentifier: 1.0.1
 
   inherits@2.0.4: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -1522,9 +1701,16 @@ snapshots:
     dependencies:
       sourcemap-codec: 1.4.8
 
+  merge2@1.4.1: {}
+
   mersenne-twister@1.1.0: {}
 
   meshoptimizer@1.1.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
 
   mime@1.6.0: {}
 
@@ -1536,11 +1722,15 @@ snapshots:
 
   node-releases@2.0.38: {}
 
+  normalize-path@3.0.0: {}
+
   nosleep.js@0.12.0: {}
 
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  p-map@7.0.4: {}
 
   pako@2.1.0: {}
 
@@ -1572,6 +1762,8 @@ snapshots:
       '@protobufjs/utf8': 1.1.0
       '@types/node': 25.6.0
       long: 5.3.2
+
+  queue-microtask@1.2.3: {}
 
   quickselect@3.0.0: {}
 
@@ -1605,11 +1797,17 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
   resium@1.21.0(cesium@1.140.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       cesium: 1.140.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  reusify@1.1.0: {}
 
   rollup-plugin-external-globals@0.6.1(rollup@4.60.2):
     dependencies:
@@ -1649,6 +1847,10 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.2
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   scheduler@0.23.2:
     dependencies:
@@ -1696,6 +1898,10 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   toidentifier@1.0.1: {}
 
   topojson-client@3.1.0:
@@ -1728,6 +1934,15 @@ snapshots:
     transitivePeerDependencies:
       - rollup
       - supports-color
+
+  vite-plugin-static-copy@2.3.2(vite@6.4.2(@types/node@25.6.0)):
+    dependencies:
+      chokidar: 3.6.0
+      fast-glob: 3.3.3
+      fs-extra: 11.3.4
+      p-map: 7.0.4
+      picocolors: 1.1.1
+      vite: 6.4.2(@types/node@25.6.0)
 
   vite@6.4.2(@types/node@25.6.0):
     dependencies:

--- a/web/renderer/src/components/CesiumScene.tsx
+++ b/web/renderer/src/components/CesiumScene.tsx
@@ -35,8 +35,6 @@ export function CesiumScene({ children }: CesiumSceneProps) {
     <>
       <Viewer
         full
-        timeline={false}
-        animation={false}
         baseLayerPicker={false}
         geocoder={false}
         homeButton={false}

--- a/web/renderer/src/components/CesiumScene.tsx
+++ b/web/renderer/src/components/CesiumScene.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { CameraFlyTo, Viewer } from "resium";
 import { Cartesian3, Ion, Math as CesiumMath } from "cesium";
 
@@ -24,7 +24,11 @@ const NASHVILLE_ORIENTATION = {
   roll: 0,
 };
 
-export function CesiumScene() {
+type CesiumSceneProps = {
+  children?: ReactNode;
+};
+
+export function CesiumScene({ children }: CesiumSceneProps) {
   const [recenterToken, setRecenterToken] = useState(0);
 
   return (
@@ -47,6 +51,7 @@ export function CesiumScene() {
           duration={recenterToken === 0 ? 0 : FLY_DURATION_S}
           once
         />
+        {children}
       </Viewer>
       <button
         type="button"

--- a/web/renderer/src/components/CzmlLoader.tsx
+++ b/web/renderer/src/components/CzmlLoader.tsx
@@ -1,0 +1,14 @@
+import { CzmlDataSource } from "resium";
+
+type CzmlLoaderProps = {
+  url: string;
+};
+
+/**
+ * Mounts a Resium CzmlDataSource for the given URL inside a parent <Viewer>.
+ * Switching the URL is handled by remounting via React `key` from the parent
+ * so the previous data source unmounts cleanly before the next one loads.
+ */
+export function CzmlLoader({ url }: CzmlLoaderProps) {
+  return <CzmlDataSource data={url} />;
+}

--- a/web/renderer/src/components/CzmlSelector.tsx
+++ b/web/renderer/src/components/CzmlSelector.tsx
@@ -1,0 +1,40 @@
+export type DemoKey = "catalog" | "vignette";
+
+export const DEMO_URLS: Record<DemoKey, string> = {
+  catalog: "/czml/effect-catalog.czml",
+  vignette: "/czml/nashville-vignette.czml",
+};
+
+const DEMO_LABELS: Record<DemoKey, string> = {
+  catalog: "Effect catalog",
+  vignette: "Nashville vignette",
+};
+
+type CzmlSelectorProps = {
+  value: DemoKey | null;
+  onChange: (next: DemoKey | null) => void;
+};
+
+export function CzmlSelector({ value, onChange }: CzmlSelectorProps) {
+  return (
+    <div className="czml-selector" role="radiogroup" aria-label="Static CZML demo">
+      <button
+        type="button"
+        className={`czml-selector__btn ${value === null ? "is-active" : ""}`}
+        onClick={() => onChange(null)}
+      >
+        None
+      </button>
+      {(Object.keys(DEMO_URLS) as DemoKey[]).map((key) => (
+        <button
+          type="button"
+          key={key}
+          className={`czml-selector__btn ${value === key ? "is-active" : ""}`}
+          onClick={() => onChange(key)}
+        >
+          {DEMO_LABELS[key]}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/renderer/src/routes/ScenarioRoot.tsx
+++ b/web/renderer/src/routes/ScenarioRoot.tsx
@@ -1,9 +1,18 @@
-import { useParams } from "react-router-dom";
+import { useState } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
 import { Excon } from "../layouts/Excon";
 import { CesiumScene } from "../components/CesiumScene";
+import { CzmlLoader } from "../components/CzmlLoader";
+import { CzmlSelector, DEMO_URLS, type DemoKey } from "../components/CzmlSelector";
 
 export function ScenarioRoot() {
   const { tenantId, scenarioId } = useParams<{ tenantId: string; scenarioId: string }>();
+  const [searchParams] = useSearchParams();
+  const isDev = searchParams.get("dev") === "1";
+
+  // In dev mode, default to the catalog so the toggle UX is immediately visible.
+  // Outside dev mode, no static CZML is loaded — production live data lands in WS-503.
+  const [demo, setDemo] = useState<DemoKey | null>(isDev ? "catalog" : null);
 
   return (
     <Excon
@@ -14,7 +23,14 @@ export function ScenarioRoot() {
           <p>scenario: {scenarioId}</p>
         </div>
       }
-      map={<CesiumScene />}
+      map={
+        <>
+          <CesiumScene>
+            {demo && <CzmlLoader key={demo} url={DEMO_URLS[demo]} />}
+          </CesiumScene>
+          {isDev && <CzmlSelector value={demo} onChange={setDemo} />}
+        </>
+      }
       actions={
         <div className="placeholder">
           <h2>Actions</h2>

--- a/web/renderer/src/styles.css
+++ b/web/renderer/src/styles.css
@@ -91,6 +91,41 @@ body,
   border-color: #888;
 }
 
+.czml-selector {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 10;
+  display: flex;
+  gap: 4px;
+  background: rgba(20, 20, 20, 0.85);
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 4px;
+}
+
+.czml-selector__btn {
+  padding: 4px 10px;
+  background: transparent;
+  color: #ccc;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.czml-selector__btn:hover {
+  color: #fff;
+  border-color: #555;
+}
+
+.czml-selector__btn.is-active {
+  background: rgba(140, 200, 255, 0.18);
+  color: #8ec5ff;
+  border-color: #4d6f8a;
+}
+
 .placeholder h2 {
   margin: 0 0 8px;
   font-size: 14px;

--- a/web/renderer/tsconfig.app.tsbuildinfo
+++ b/web/renderer/tsconfig.app.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/app.tsx","./src/main.tsx","./src/router.tsx","./src/components/banner.tsx","./src/components/cesiumscene.tsx","./src/layouts/excon.tsx","./src/routes/index.tsx","./src/routes/scenarioroot.tsx"],"version":"5.9.3"}

--- a/web/renderer/vite.config.ts
+++ b/web/renderer/vite.config.ts
@@ -1,9 +1,21 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import cesium from "vite-plugin-cesium";
+import { viteStaticCopy } from "vite-plugin-static-copy";
 
 export default defineConfig({
-  plugins: [react(), cesium()],
+  plugins: [
+    react(),
+    cesium(),
+    // Make the WS-203/WS-204 hand-authored CZML demos available under
+    // /czml/* in dev and dist. They live at the repo-root czml/demos/ so
+    // multiple consumers (renderer, smoke harnesses) can share them.
+    viteStaticCopy({
+      targets: [
+        { src: "../../czml/demos/*.czml", dest: "czml" },
+      ],
+    }),
+  ],
   server: {
     port: 5173,
   },


### PR DESCRIPTION
## Summary
- Hooks the WS-203 effect catalog and WS-204 Nashville vignette into the Resium scaffold via Resium's \`<CzmlDataSource>\`. Static path only — no kernel; live data lands in WS-503.
- \`vite-plugin-static-copy\` surfaces \`czml/demos/*\` under \`/czml/*\` in dev and dist, so consumers can fetch them via \`fetch('/czml/effect-catalog.czml')\` without a build step in the demos directory.
- \`CzmlSelector\` is the dev-only toggle (None / Effect catalog / Nashville vignette), top-left, behind \`?dev=1\`. \`CzmlLoader\` mounts the chosen one inside the existing \`CesiumScene\` (refactored to accept children).
- \`ScenarioRoot\` lifts demo-key state and defaults to \`catalog\` when \`?dev=1\` is set so the toggle UX is immediately useful.
- Re-enabled Cesium's timeline + animation widgets so staggered CZML can be scrubbed / played.
- \`*.tsbuildinfo\` added to the renderer \`.gitignore\` (was leaking into commits via prior typecheck runs).

Closes #27.

## Why this branch is off ws-501
The renderer doesn't exist on \`main\` yet (PR #38 is in review), so this PR chains off \`ws-501/resium-scaffold\` plus a merge of latest \`main\` to pick up the WS-203 demos. When #38 merges, GitHub will rebase this PR's diff onto main automatically; if it conflicts, I'll rebase manually.

## Test plan
- [x] \`cd web/renderer && pnpm install && pnpm dev\`
- [x] Open \`http://localhost:5173/demo/scenarios/demo?dev=1&token=YOUR_VITE_CESIUM_ION_TOKEN_VALUE\`
- [x] Top-left toggle present; "Effect catalog" highlighted by default; 9 effects visible over Nashville
- [x] Click "Nashville vignette" → catalog unmounts, vignette loads; hit play on the timeline (bottom-left of Cesium) → scripted UAS / EW / radar / fires sequence plays back
- [x] Click "None" → both demos unmount, bare Nashville scene remains
- [x] Without \`?dev=1\`, no toggle is visible and no demo is auto-loaded
- [x] Recenter button still flies camera back to Nashville