### PR TITLE
WS-402 — Officer interface tools (PyRapide event emitters)

### DIFF
--- a/agents/tools/README.md
+++ b/agents/tools/README.md
@@ -1,0 +1,210 @@
+# `almighty-officer-tools` — WS-402
+
+> **Classification:** UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY
+
+CrewAI tool wrappers for each of the 20 officer interface verbs locked
+in [`docs/schema/officer-interfaces.md`](../../docs/schema/officer-interfaces.md)
+(WS-105). Sits between agents (WS-403 / WS-404 / WS-405) and the kernel:
+
+```
+agent → OfficerTool._run(...) → capability gate → validator → kernel.commit()
+```
+
+Tools never mutate state directly. Every state change goes through
+`almighty_kernel.NamespacedDag.commit()` per the
+[better-late-than-never](../../docs/better-late-than-never.md) doc.
+
+## What each tool does
+
+For every call, in order:
+
+1. **Capability-verb gate.** If the bound profile's
+   `action_verbs_available` does not contain this tool's `VERB`, raise
+   `ToolError` immediately — the validator is **never** consulted.
+   Per WS-105 / runbook §1093.
+2. **Args validation.** Pydantic schema (`args_schema`) parses the
+   keyword args. Extra checks (e.g., `delegate.delegated_verbs ⊆
+   own action_verbs_available`, `escalate.to_echelon` strictly higher,
+   `send` requires recipient_entity_id XOR recipient_role) raise
+   `ToolError` or `ValidationError` synchronously.
+3. **Validator gate (CZML-emitting verbs only).** Build a params dict
+   keyed on the template's `capability_constraints`, call the WS-202
+   validator in-process. On `accepted=False`, raise
+   `ToolError(reason)`.
+4. **Kernel commit.** Build a `KernelEvent`, hand it to
+   `NamespacedDag.commit()`. Returns `event_id`, the verb, the officer
+   type, and the validator outcome (`accepted` / `skipped`).
+
+Mover verbs (`move_to`, `follow_route`, `halt`, `assume_posture`),
+Communicator non-spatial verbs (`send`, `report`, and `relay` when not
+airborne or `advertise_corridor=false`), and all four Commander verbs
+**skip** the validator step. Their effect family is `None`.
+
+## API contract
+
+```python
+from uuid import UUID
+
+from almighty_czml_validator import Validator
+from almighty_kernel.dag import NamespacedDag
+
+from almighty_officer_tools import OfficerToolContext, build_all_tools
+
+ctx = OfficerToolContext(
+    tenant_id=UUID("..."),
+    scenario_id=UUID("..."),
+    turn=0,
+    agent_entity_id=UUID("..."),
+    capability_profile=us_bct_profile_dict,    # WS-106 / WS-107 shape
+    kernel_dag=NamespacedDag(),
+    validator=Validator(),                      # in-process
+)
+
+tools = build_all_tools(ctx)                   # name-keyed dict, 20 entries
+
+result = tools["engage"]._run(
+    target_entity_id=UUID("..."),
+    weapon_system="notional.indirect.medium",
+    volume_count=4,
+    range_m=10_000.0,
+    time_of_flight_s=25.0,
+)
+# {'event_id': '...', 'verb': 'engage', 'officer_type': 'EFFECTOR', 'validator': 'accepted'}
+```
+
+`build_all_tools` is the convenience entry. WS-403 / WS-404 / WS-405
+will typically construct the **subset** of tools each crew agent needs
+(Sensor-only S2 agent gets the four Sensor tools; company commanders
+get Mover + Effector + Communicator).
+
+### Verb-by-verb tool inventory
+
+| Officer | Verb | EFFECT_FAMILY | Notes |
+|---|---|---|---|
+| Sensor | `detect` | per-modality | `EO_IR` → none; `RF` → `ew_cone`; `RADAR` → `radar_fan`; ACOUSTIC/SEISMIC/MASINT_MULTI → `masint_cell`. |
+| Sensor | `track` | none | Continuation; no spatial artifact. |
+| Sensor | `classify` | `keyhole_footprint` | Tighter footprint scales with dwell. |
+| Sensor | `lose_track` | none | |
+| Effector | `engage` | `indirect_fire_arc` | Args mutually-exclusive: target entity XOR coord. |
+| Effector | `suppress` | `indirect_fire_arc` | `mode='suppression'` on the event payload. |
+| Effector | `destroy` | `indirect_fire_arc` | Adds `stake='high'` to payload for WS-405 adjudicator. |
+| Effector | `disable` | per-method | `KINETIC` → `indirect_fire_arc`; `EW` → `jamming_circle`; `CYBER` → none. |
+| Mover | `move_to` | none | |
+| Mover | `follow_route` | none | |
+| Mover | `halt` | none | No args. |
+| Mover | `assume_posture` | none | Posture-transition validity is a downstream profile check. |
+| Communicator | `send` | none | recipient_entity_id XOR recipient_role. |
+| Communicator | `relay` | conditional | Emits `uas_corridor` only when `is_airborne=True` AND `profile.communicator.advertise_corridor=True`. |
+| Communicator | `jam` | `jamming_circle` | Polygon ≥ 3 vertices; v1 always omni-circle (directional `ew_cone` is a v2 dispatch). |
+| Communicator | `report` | none | |
+| Commander | `issue_order` | none | to_entity_id XOR to_echelon. |
+| Commander | `request_support` | none | FIRES / MEDEVAC require target coord. |
+| Commander | `delegate` | none | `delegated_verbs ⊆ own action_verbs_available` (rejects with `ToolError`). |
+| Commander | `escalate` | none | `to_echelon` strictly higher than profile.commander.echelon (rejects sideways/downward). |
+
+## What downstream crews must respect
+
+These are the constraints lifted out of WS-105, the glossary, and
+[better-late-than-never](../../docs/better-late-than-never.md). They are
+not enforced by the harness — they're agent-author responsibilities:
+
+- **The 20-verb vocabulary is locked.** If a crew needs a 21st verb,
+  open an issue against WS-105 first. Don't add an ad-hoc tool.
+- **`destroy` is its own verb, not an `engage` flag.** The override
+  gateway (WS-303) and adjudicator (WS-405) key off the verb name. Use
+  `destroy` when you mean it.
+- **Mover verbs emit no spatial artifacts.** Don't author a "movement"
+  artifact family. Position updates flow through the live adapter
+  (WS-503) which reads entity-state changes directly.
+- **`escalate` is strictly upward.** Sideways escalation is rejected as
+  a control-flow trick.
+- **`force_affiliation = RED` is a precondition for `uncertainty`.**
+  Knowledge of an opponent's bands belongs to the opposing side's
+  profile.
+
+## Run
+
+```bash
+# From this directory (agents/tools/):
+python3.13 -m venv .venv
+source .venv/bin/activate
+
+# Install editable deps in topological order (kernel and validator first):
+pip install -e ../../kernel
+pip install -e ../../services/czml-validator
+pip install -e ".[dev]"
+
+# Run the test suite:
+pytest -v
+```
+
+## Tests — 35 passing
+
+- **One happy-path per verb** for the 20 verbs (some have multiple,
+  e.g., `detect` exercises `RADAR` happy + `EO_IR` no-validator;
+  `disable` exercises KINETIC + CYBER; `relay` exercises both
+  airborne+corridor and non-airborne paths).
+- **Reject paths** for: validator out-of-range (`detect` RADAR, `engage`
+  range, `jam` power), capability gate (us-bct lacks `jam` and
+  `disable`), `delegate` not-in-authority, `escalate`
+  not-strictly-higher (sideways AND downward).
+- **Sanity tests** for: 20 verbs registered with unique names, all
+  classes subclass `crewai.tools.BaseTool`.
+
+Profiles loaded fresh from `kernel/capability-profiles/` at session
+start; each test uses a real in-memory `NamespacedDag` and the real
+WS-202 `Validator`. No mocks of either: when a tool fires, it actually
+commits to the DAG and actually consults the validator. Drift in either
+upstream surfaces immediately on `pytest`.
+
+## Layout
+
+```
+agents/tools/
+├── pyproject.toml
+├── README.md                                        ← this file
+├── src/almighty_officer_tools/
+│   ├── __init__.py                                  ← public exports
+│   ├── context.py                                   ← OfficerToolContext, ToolError
+│   ├── base.py                                      ← OfficerToolBase
+│   ├── registry.py                                  ← build_all_tools, ALL_TOOL_CLASSES
+│   ├── sensor/{detect,track,classify,lose_track}.py
+│   ├── effector/{engage,suppress,destroy,disable}.py
+│   ├── mover/{move_to,follow_route,halt,assume_posture}.py
+│   ├── communicator/{send,relay,jam,report}.py
+│   └── commander/{issue_order,request_support,delegate,escalate}.py
+└── tests/
+    ├── conftest.py                                  ← profile + DAG + validator fixtures
+    ├── test_base.py                                 ← gate + structural sanity
+    └── test_{sensor,effector,mover,communicator,commander}.py
+```
+
+## Notes / open questions
+
+- **Posture transition matrix** (Mover.assume_posture): the validator
+  doesn't yet enforce `posture_transitions` from the profile. v1 commits
+  the event; the adjudicator (WS-405) is responsible for catching
+  invalid transitions. If profile-side enforcement is needed sooner,
+  add a check in `AssumePostureTool._build_event_payload`.
+- **`disable.method=EW` validator path**: routes to `jamming_circle`,
+  which means the *Effector* tool's commit goes through a
+  *Communicator*-shaped template. v1 accepts that overlap; if WS-405
+  needs to discriminate "EW disable" from "actual jam", it can use the
+  source event's `action_verb` and `payload.method`.
+- **Directional vs omni jammers**: the runbook hints that single-
+  aperture directional platforms should emit `ew_cone` for `jam`. v1
+  always uses `jamming_circle`; the dispatch is a follow-up when
+  WS-201 templates pick up an `ew-cone` jamming variant.
+- **CrewAI agent integration**: tests call `_run(**kwargs)` directly,
+  bypassing the LLM-tool-call loop. That's the typical pattern for
+  CrewAI tool unit tests. Real agent invocation happens in WS-403 /
+  WS-404 / WS-405 when the crews are stood up.
+
+## See also
+
+- [`docs/schema/officer-interfaces.md`](../../docs/schema/officer-interfaces.md) — verb signatures (WS-105).
+- [`docs/schema/capability-profiles.md`](../../docs/schema/capability-profiles.md) — profile schema (WS-106).
+- [`docs/schema/artifacts.md`](../../docs/schema/artifacts.md) — verb→artifact mapping (WS-108).
+- [`services/czml-validator/`](../../services/czml-validator/) — in-process validator (WS-202).
+- [`kernel/almighty_kernel/dag.py`](../../kernel/almighty_kernel/dag.py) — `NamespacedDag.commit()` (WS-104).
+- WS-403 (#23) / WS-404 (#24) / WS-405 (#25) — crews that consume these tools.

--- a/agents/tools/pyproject.toml
+++ b/agents/tools/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "almighty-officer-tools"
+version = "0.1.0"
+description = "Almighty CrewAI tool wrappers for the 20 officer interface verbs (WS-402)"
+requires-python = ">=3.11"
+authors = [{ name = "Almighty Team" }]
+dependencies = [
+    "crewai>=0.95",
+    "pydantic>=2.6",
+    "almighty-kernel",
+    "almighty-czml-validator",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["almighty_officer_tools*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/agents/tools/src/almighty_officer_tools/__init__.py
+++ b/agents/tools/src/almighty_officer_tools/__init__.py
@@ -1,0 +1,17 @@
+"""Almighty officer interface tool wrappers (WS-402).
+
+Twenty CrewAI tools, one per officer verb. See README.md for the
+integration shape and `docs/schema/officer-interfaces.md` (WS-105) for
+the canonical verb contracts.
+"""
+
+from .base import OfficerToolBase
+from .context import OfficerToolContext, ToolError
+from .registry import build_all_tools
+
+__all__ = [
+    "OfficerToolBase",
+    "OfficerToolContext",
+    "ToolError",
+    "build_all_tools",
+]

--- a/agents/tools/src/almighty_officer_tools/base.py
+++ b/agents/tools/src/almighty_officer_tools/base.py
@@ -1,0 +1,145 @@
+"""OfficerToolBase — common gate-then-validate-then-commit machinery.
+
+Each verb subclasses this and declares:
+
+- ``OFFICER_TYPE`` — one of SENSOR/EFFECTOR/MOVER/COMMUNICATOR/COMMANDER.
+- ``VERB`` — the lowercase verb name (matches WS-105).
+- ``EFFECT_FAMILY`` — the spatial-family key used by the validator
+  (e.g., ``jamming_circle``); ``None`` for non-CZML verbs.
+- ``args_schema`` — a pydantic model describing the verb's parameter set
+  per WS-105.
+- ``_build_event_payload(args)`` — converts the validated args into the
+  ``KernelEvent.payload`` dict.
+- ``_build_validator_params(args)`` — only required when EFFECT_FAMILY is
+  not None; returns the post-substitution param dict the WS-202
+  validator gates on.
+
+The base handles, in order:
+
+  1. Capability-verb gate. If ``self.VERB`` is not in
+     ``profile.action_verbs_available``, raise ``ToolError`` immediately
+     **without** touching the validator. (Per WS-105 / runbook §1093.)
+  2. (CZML-emitting verbs only) Build params and call the validator
+     in-process. On ``accepted=False``, raise ``ToolError(reason)``.
+  3. Build a ``KernelEvent`` and commit via ``NamespacedDag.commit()`` —
+     the only sanctioned write path per
+     ``docs/better-late-than-never.md`` (Schema and data model § "Don't
+     INSERT INTO events directly").
+
+Returns the committed event_id and the validator outcome (or "skipped"
+for non-CZML verbs) as a dict so a CrewAI agent can chain on it.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, ClassVar
+from uuid import uuid4
+
+from almighty_czml_validator import ValidateRequest
+from almighty_kernel.dag import KernelEvent
+from crewai.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, PrivateAttr
+
+from .context import OfficerToolContext, ToolError
+
+
+class OfficerToolBase(BaseTool):
+    """Common base for the 20 officer interface tools."""
+
+    OFFICER_TYPE: ClassVar[str]
+    VERB: ClassVar[str]
+    EFFECT_FAMILY: ClassVar[str | None] = None  # default non-spatial
+
+    # Pydantic v2 fields the BaseTool subclass requires; we set them in
+    # `__init__` from class-level constants so each verb file just needs
+    # to define `_TOOL_NAME` and `_TOOL_DESCRIPTION` plus its args schema.
+    name: str = "almighty.officer-tool.base"
+    description: str = "abstract base"
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    _ctx: OfficerToolContext = PrivateAttr()
+
+    def __init__(self, ctx: OfficerToolContext, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._ctx = ctx
+
+    # ---- subclass hooks ---------------------------------------------------
+
+    @abstractmethod
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        """Return the ``payload`` dict for the KernelEvent."""
+
+    def _build_validator_params(self, args: BaseModel) -> dict[str, Any]:
+        """Required when ``EFFECT_FAMILY`` is set. Default raises so
+        non-CZML verbs don't accidentally call the validator path."""
+        raise NotImplementedError(
+            f"{type(self).__name__} declares EFFECT_FAMILY={self.EFFECT_FAMILY!r} "
+            f"but did not implement _build_validator_params"
+        )
+
+    def _effect_family_for(self, args: BaseModel) -> str | None:
+        """Resolve the effect family for this call. Default returns the
+        class-level ``EFFECT_FAMILY``. Verbs whose family depends on
+        runtime args (e.g. ``Sensor.detect`` on modality) override."""
+        del args
+        return self.EFFECT_FAMILY
+
+    # ---- core flow --------------------------------------------------------
+
+    def _run(self, **kwargs: Any) -> dict[str, Any]:
+        ctx = self._ctx
+        # Step 1: capability-verb gate. Raises before any validator call.
+        verbs = set(ctx.capability_profile.get("action_verbs_available", []))
+        if self.VERB not in verbs:
+            raise ToolError(
+                f"capability gate: agent profile lacks verb '{self.VERB}'"
+            )
+
+        # Parse / validate the args via the pydantic schema.
+        if self.args_schema is None:
+            raise ToolError(f"{type(self).__name__}: args_schema is required")
+        args = self.args_schema.model_validate(kwargs)
+
+        # Step 2 (CZML verbs only): build params and call validator.
+        validator_outcome: str
+        family = self._effect_family_for(args)
+        if family is not None:
+            template_id = family.replace("_", "-")
+            params = self._build_validator_params(args)
+            request = ValidateRequest(
+                template_id=template_id,
+                template_version=1,
+                params=params,
+                agent_id=str(ctx.agent_entity_id),
+                capability_profile=ctx.capability_profile,
+            )
+            result = ctx.validator.validate(request)
+            if not result.accepted:
+                raise ToolError(
+                    f"validator rejected '{self.VERB}': {'; '.join(result.reasons)}"
+                )
+            validator_outcome = "accepted"
+        else:
+            validator_outcome = "skipped"
+
+        # Step 3: commit the event through the namespaced DAG.
+        event = KernelEvent(
+            event_id=uuid4(),
+            tenant_id=ctx.tenant_id,
+            scenario_id=ctx.scenario_id,
+            turn=ctx.turn,
+            source_officer_type=self.OFFICER_TYPE,
+            source_entity_id=ctx.agent_entity_id,
+            action_verb=self.VERB,
+            payload=self._build_event_payload(args),
+            causal_predecessors=[],
+        )
+        ctx.kernel_dag.commit(event)
+
+        return {
+            "event_id": str(event.event_id),
+            "verb": self.VERB,
+            "officer_type": self.OFFICER_TYPE,
+            "validator": validator_outcome,
+        }

--- a/agents/tools/src/almighty_officer_tools/commander/__init__.py
+++ b/agents/tools/src/almighty_officer_tools/commander/__init__.py
@@ -1,0 +1,6 @@
+from .delegate import DelegateTool
+from .escalate import EscalateTool
+from .issue_order import IssueOrderTool
+from .request_support import RequestSupportTool
+
+__all__ = ["IssueOrderTool", "RequestSupportTool", "DelegateTool", "EscalateTool"]

--- a/agents/tools/src/almighty_officer_tools/commander/delegate.py
+++ b/agents/tools/src/almighty_officer_tools/commander/delegate.py
@@ -1,0 +1,46 @@
+"""Commander.delegate — hand subordinate authority for a subset of verbs.
+
+Per WS-105: ``delegated_verbs ⊆ this_entity.capability.action_verbs_available``.
+The base capability gate fires on this verb itself; the subset check on
+delegated_verbs happens here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from ..base import OfficerToolBase
+from ..context import ToolError
+
+
+class DelegateArgs(BaseModel):
+    to_entity_id: UUID
+    delegated_verbs: list[str] = Field(min_length=1)
+    ttl_turns: int = Field(ge=1)
+
+
+class DelegateTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "COMMANDER"
+    VERB: ClassVar[str] = "delegate"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.commander.delegate"
+    description: str = "Hand subordinate authority for a subset of verbs to another entity."
+    args_schema: type[BaseModel] = DelegateArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, DelegateArgs)
+        owned = set(self._ctx.capability_profile.get("action_verbs_available", []))
+        bad = sorted(set(args.delegated_verbs) - owned)
+        if bad:
+            raise ToolError(
+                f"delegate: cannot delegate verbs not in own authority: {bad}"
+            )
+        return {
+            "to_entity_id": str(args.to_entity_id),
+            "delegated_verbs": list(args.delegated_verbs),
+            "ttl_turns": args.ttl_turns,
+        }

--- a/agents/tools/src/almighty_officer_tools/commander/escalate.py
+++ b/agents/tools/src/almighty_officer_tools/commander/escalate.py
@@ -1,0 +1,66 @@
+"""Commander.escalate — push a decision to higher echelon.
+
+Per WS-105 and the better-late-than-never doc: `to_echelon` MUST be
+strictly higher than the issuing entity's echelon. The check happens
+here using ``self._ctx.capability_profile.commander.echelon`` as the
+issuing echelon.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from ..base import OfficerToolBase
+from ..context import ToolError
+
+EscalationSeverity = Literal["ROUTINE", "PRIORITY", "FLASH"]
+Echelon = Literal["COMPANY", "BATTALION", "BRIGADE", "DIVISION", "WHITE_CELL"]
+
+_ECHELON_RANK: dict[Echelon, int] = {
+    "COMPANY": 1,
+    "BATTALION": 2,
+    "BRIGADE": 3,
+    "DIVISION": 4,
+    "WHITE_CELL": 5,
+}
+
+
+class EscalateArgs(BaseModel):
+    reason: str = Field(min_length=1, max_length=2000)
+    severity: EscalationSeverity
+    to_echelon: Echelon
+    references: list[UUID] = Field(default_factory=list)
+
+
+class EscalateTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "COMMANDER"
+    VERB: ClassVar[str] = "escalate"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.commander.escalate"
+    description: str = "Push a decision to a strictly higher echelon."
+    args_schema: type[BaseModel] = EscalateArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, EscalateArgs)
+        commander = self._ctx.capability_profile.get("commander") or {}
+        own_ech = commander.get("echelon")
+        if own_ech is None or own_ech not in _ECHELON_RANK:
+            raise ToolError(
+                "escalate: profile.commander.echelon missing or unknown — "
+                "cannot determine 'strictly higher' rank"
+            )
+        if _ECHELON_RANK[args.to_echelon] <= _ECHELON_RANK[own_ech]:
+            raise ToolError(
+                f"escalate: to_echelon='{args.to_echelon}' is not strictly higher "
+                f"than own echelon='{own_ech}'"
+            )
+        return {
+            "reason": args.reason,
+            "severity": args.severity,
+            "to_echelon": args.to_echelon,
+            "references": [str(r) for r in args.references],
+        }

--- a/agents/tools/src/almighty_officer_tools/commander/issue_order.py
+++ b/agents/tools/src/almighty_officer_tools/commander/issue_order.py
@@ -1,0 +1,50 @@
+"""Commander.issue_order — direct a subordinate to take action."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, model_validator
+
+from ..base import OfficerToolBase
+
+OrderType = Literal["MOVE", "ATTACK", "DEFEND", "RECON", "SUPPORT", "WITHDRAW"]
+OrderPriority = Literal["LOW", "MEDIUM", "HIGH"]
+Echelon = Literal["COMPANY", "BATTALION", "BRIGADE", "DIVISION", "WHITE_CELL"]
+
+
+class IssueOrderArgs(BaseModel):
+    order_type: OrderType
+    order_payload: dict[str, Any]
+    to_entity_id: UUID | None = None
+    to_echelon: Echelon | None = None
+    priority: OrderPriority = "MEDIUM"
+
+    @model_validator(mode="after")
+    def _to_xor(self) -> "IssueOrderArgs":
+        if (self.to_entity_id is None) == (self.to_echelon is None):
+            raise ValueError(
+                "issue_order requires exactly one of to_entity_id or to_echelon"
+            )
+        return self
+
+
+class IssueOrderTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "COMMANDER"
+    VERB: ClassVar[str] = "issue_order"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.commander.issue_order"
+    description: str = "Direct a subordinate to take action."
+    args_schema: type[BaseModel] = IssueOrderArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, IssueOrderArgs)
+        return {
+            "order_type": args.order_type,
+            "order_payload": args.order_payload,
+            "to_entity_id": str(args.to_entity_id) if args.to_entity_id else None,
+            "to_echelon": args.to_echelon,
+            "priority": args.priority,
+        }

--- a/agents/tools/src/almighty_officer_tools/commander/request_support.py
+++ b/agents/tools/src/almighty_officer_tools/commander/request_support.py
@@ -1,0 +1,62 @@
+"""Commander.request_support — ask higher echelon for an asset."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from ..base import OfficerToolBase
+
+SupportType = Literal["FIRES", "ISR", "MEDEVAC", "LOGISTICS", "EW", "AIR"]
+RequestPriority = Literal["LOW", "MEDIUM", "HIGH", "IMMEDIATE"]
+
+
+class RequestSupportArgs(BaseModel):
+    support_type: SupportType
+    justification: str = Field(min_length=1, max_length=2000)
+    priority: RequestPriority
+    target_lat_deg: float | None = Field(default=None, ge=-90, le=90)
+    target_lon_deg: float | None = Field(default=None, ge=-180, le=180)
+    target_alt_m: float | None = None
+
+    @model_validator(mode="after")
+    def _coord_for_fires_medevac(self) -> "RequestSupportArgs":
+        needs_coord = self.support_type in ("FIRES", "MEDEVAC")
+        has_coord = (
+            self.target_lat_deg is not None
+            and self.target_lon_deg is not None
+            and self.target_alt_m is not None
+        )
+        if needs_coord and not has_coord:
+            raise ValueError(
+                f"request_support({self.support_type}) requires target_lat_deg / "
+                f"target_lon_deg / target_alt_m"
+            )
+        return self
+
+
+class RequestSupportTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "COMMANDER"
+    VERB: ClassVar[str] = "request_support"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.commander.request_support"
+    description: str = "Ask higher echelon (or a sister unit) for an asset."
+    args_schema: type[BaseModel] = RequestSupportArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, RequestSupportArgs)
+        target = None
+        if args.target_lat_deg is not None:
+            target = {
+                "lat_deg": args.target_lat_deg,
+                "lon_deg": args.target_lon_deg,
+                "alt_m": args.target_alt_m,
+            }
+        return {
+            "support_type": args.support_type,
+            "justification": args.justification,
+            "priority": args.priority,
+            "target_coordinate": target,
+        }

--- a/agents/tools/src/almighty_officer_tools/communicator/__init__.py
+++ b/agents/tools/src/almighty_officer_tools/communicator/__init__.py
@@ -1,0 +1,6 @@
+from .jam import JamTool
+from .relay import RelayTool
+from .report import ReportTool
+from .send import SendTool
+
+__all__ = ["SendTool", "RelayTool", "JamTool", "ReportTool"]

--- a/agents/tools/src/almighty_officer_tools/communicator/jam.py
+++ b/agents/tools/src/almighty_officer_tools/communicator/jam.py
@@ -1,0 +1,55 @@
+"""Communicator.jam — deny use of an RF band over an area.
+
+Per WS-105 + WS-108: omni jammers emit `jamming_circle`. Directional
+jammers can emit `ew_cone`; for v1 the tool always uses jamming_circle.
+WS-202 / WS-201's directional-vs-omni dispatch is a future refinement.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from ..base import OfficerToolBase
+
+RfBand = Literal["HF", "VHF", "UHF", "L", "S", "C", "X", "KU", "KA"]
+
+
+class JamArgs(BaseModel):
+    target_polygon: list[list[float]]
+    power_w: float = Field(gt=0)
+    band: RfBand
+    duration_s: float = Field(gt=0)
+    # Validator-side circle approximation; v1 keeps it simple.
+    radius_m: float = Field(gt=0, default=2_000.0)
+
+    @model_validator(mode="after")
+    def _polygon_shape(self) -> "JamArgs":
+        if len(self.target_polygon) < 3:
+            raise ValueError("jam.target_polygon must have ≥ 3 vertices")
+        return self
+
+
+class JamTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "COMMUNICATOR"
+    VERB: ClassVar[str] = "jam"
+    EFFECT_FAMILY: ClassVar[str | None] = "jamming_circle"
+
+    name: str = "almighty.communicator.jam"
+    description: str = "Deny use of an RF band over an area."
+    args_schema: type[BaseModel] = JamArgs
+
+    def _build_validator_params(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, JamArgs)
+        return {"radius_m": args.radius_m, "power_w": args.power_w}
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, JamArgs)
+        return {
+            "target_polygon": args.target_polygon,
+            "power_w": args.power_w,
+            "band": args.band,
+            "duration_s": args.duration_s,
+            "radius_m": args.radius_m,
+        }

--- a/agents/tools/src/almighty_officer_tools/communicator/relay.py
+++ b/agents/tools/src/almighty_officer_tools/communicator/relay.py
@@ -1,0 +1,66 @@
+"""Communicator.relay — forward a message between two parties.
+
+Per WS-105: when the entity is airborne AND
+``profile.communicator.advertise_corridor`` is True, the relay also
+emits a ``uas_corridor`` artifact spanning the relay path. The tool
+captures the airborne flag from a runtime arg and the corridor flag
+from the profile; both must be true to fire the validator path.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from ..base import OfficerToolBase
+
+CommsChannel = Literal["VHF", "UHF", "HF", "SATCOM", "DATA"]
+
+
+class RelayArgs(BaseModel):
+    source_entity_id: UUID
+    recipient_entity_id: UUID
+    channel: CommsChannel
+    # The agent declares whether this entity is airborne; the validator
+    # gate on uas_corridor only fires if both this and the profile's
+    # advertise_corridor are True.
+    is_airborne: bool = False
+    altitude_band_lower_m: float = Field(gt=0, default=500.0)
+    altitude_band_upper_m: float = Field(gt=0, default=2_000.0)
+    width_m: float = Field(gt=0, default=2_000.0)
+
+
+class RelayTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "COMMUNICATOR"
+    VERB: ClassVar[str] = "relay"
+    EFFECT_FAMILY: ClassVar[str | None] = None  # conditional
+
+    name: str = "almighty.communicator.relay"
+    description: str = "Forward a message between two parties via this entity."
+    args_schema: type[BaseModel] = RelayArgs
+
+    def _effect_family_for(self, args: BaseModel) -> str | None:
+        assert isinstance(args, RelayArgs)
+        comm = self._ctx.capability_profile.get("communicator", {}) or {}
+        if args.is_airborne and comm.get("advertise_corridor", False):
+            return "uas_corridor"
+        return None
+
+    def _build_validator_params(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, RelayArgs)
+        return {
+            "altitude_band_lower_m": args.altitude_band_lower_m,
+            "altitude_band_upper_m": args.altitude_band_upper_m,
+            "width_m": args.width_m,
+        }
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, RelayArgs)
+        return {
+            "source_entity_id": str(args.source_entity_id),
+            "recipient_entity_id": str(args.recipient_entity_id),
+            "channel": args.channel,
+            "is_airborne": args.is_airborne,
+        }

--- a/agents/tools/src/almighty_officer_tools/communicator/report.py
+++ b/agents/tools/src/almighty_officer_tools/communicator/report.py
@@ -1,0 +1,36 @@
+"""Communicator.report — submit a structured report to a higher echelon."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel, Field
+
+from ..base import OfficerToolBase
+
+ReportType = Literal["SITREP", "SPOTREP", "LOGSTAT", "CASEVAC", "INTREP"]
+Echelon = Literal["COMPANY", "BATTALION", "BRIGADE", "DIVISION", "WHITE_CELL"]
+
+
+class ReportArgs(BaseModel):
+    report_type: ReportType
+    report_payload: dict[str, Any]
+    to_echelon: Echelon
+
+
+class ReportTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "COMMUNICATOR"
+    VERB: ClassVar[str] = "report"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.communicator.report"
+    description: str = "Submit a structured report to a higher echelon."
+    args_schema: type[BaseModel] = ReportArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, ReportArgs)
+        return {
+            "report_type": args.report_type,
+            "report_payload": args.report_payload,
+            "to_echelon": args.to_echelon,
+        }

--- a/agents/tools/src/almighty_officer_tools/communicator/send.py
+++ b/agents/tools/src/almighty_officer_tools/communicator/send.py
@@ -1,0 +1,51 @@
+"""Communicator.send — transmit a message to a recipient (non-spatial)."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+from ..base import OfficerToolBase
+
+CommsChannel = Literal["VHF", "UHF", "HF", "SATCOM", "DATA"]
+CommsPriority = Literal["ROUTINE", "PRIORITY", "IMMEDIATE", "FLASH"]
+
+
+class SendArgs(BaseModel):
+    channel: CommsChannel
+    message_payload: dict[str, Any]
+    recipient_entity_id: UUID | None = None
+    recipient_role: str | None = None
+    priority: CommsPriority = "ROUTINE"
+
+    @model_validator(mode="after")
+    def _recipient_xor(self) -> "SendArgs":
+        if (self.recipient_entity_id is None) == (self.recipient_role is None):
+            raise ValueError(
+                "send requires exactly one of recipient_entity_id or recipient_role"
+            )
+        return self
+
+
+class SendTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "COMMUNICATOR"
+    VERB: ClassVar[str] = "send"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.communicator.send"
+    description: str = "Transmit a message to a recipient."
+    args_schema: type[BaseModel] = SendArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, SendArgs)
+        return {
+            "channel": args.channel,
+            "message_payload": args.message_payload,
+            "recipient_entity_id": (
+                str(args.recipient_entity_id) if args.recipient_entity_id else None
+            ),
+            "recipient_role": args.recipient_role,
+            "priority": args.priority,
+        }

--- a/agents/tools/src/almighty_officer_tools/context.py
+++ b/agents/tools/src/almighty_officer_tools/context.py
@@ -1,0 +1,49 @@
+"""OfficerToolContext + ToolError.
+
+Each tool instance is bound to one (agent, capability_profile, scenario)
+context at construction time. The runtime parameters that change per
+tool call (verb-specific args) are passed to ``_run`` as keyword args.
+
+This is the contract WS-403 / WS-404 / WS-405 will produce a context
+for when they instantiate per-agent tool sets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from almighty_czml_validator import Validator
+from almighty_kernel.dag import NamespacedDag
+
+
+class ToolError(RuntimeError):
+    """Raised when a tool call cannot proceed.
+
+    Distinct exception type so CrewAI agent loops can recognize tool-side
+    rejection (capability gate or validator reject) as distinct from a
+    raw library exception.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass
+class OfficerToolContext:
+    """Inputs every officer tool receives at construction.
+
+    The fields below MUST be supplied by whoever instantiates the tool
+    (in v1, the test harness; in WS-403/404/405, the crew that wires
+    agents to tools).
+    """
+
+    tenant_id: UUID
+    scenario_id: UUID
+    turn: int
+    agent_entity_id: UUID
+    capability_profile: dict[str, Any]
+    kernel_dag: NamespacedDag
+    validator: Validator

--- a/agents/tools/src/almighty_officer_tools/effector/__init__.py
+++ b/agents/tools/src/almighty_officer_tools/effector/__init__.py
@@ -1,0 +1,6 @@
+from .destroy import DestroyTool
+from .disable import DisableTool
+from .engage import EngageTool
+from .suppress import SuppressTool
+
+__all__ = ["EngageTool", "SuppressTool", "DestroyTool", "DisableTool"]

--- a/agents/tools/src/almighty_officer_tools/effector/destroy.py
+++ b/agents/tools/src/almighty_officer_tools/effector/destroy.py
@@ -1,0 +1,62 @@
+"""Effector.destroy — remove a target from the scenario.
+
+Always high-stakes per WS-105 § Effector.destroy and WS-108 § 4.6
+(`always-contested` flow). The override gateway floors this at
+`always-contested`; the tool itself proceeds to commit and the
+adjudicator (WS-405) holds it for human ack downstream.
+
+The DoD-required `justification` field is captured on the event payload
+for AAR.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from ..base import OfficerToolBase
+
+
+class DestroyArgs(BaseModel):
+    target_entity_id: UUID
+    weapon_system: str = Field(min_length=1)
+    volume_count: int = Field(ge=1)
+    justification: str = Field(min_length=1, max_length=2000)
+    range_m: float = Field(gt=0)
+    time_of_flight_s: float = Field(ge=0)
+    dispersion_ellipse_a_m: float = Field(gt=0, default=50.0)
+    dispersion_ellipse_b_m: float = Field(gt=0, default=50.0)
+
+
+class DestroyTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "EFFECTOR"
+    VERB: ClassVar[str] = "destroy"
+    EFFECT_FAMILY: ClassVar[str | None] = "indirect_fire_arc"
+
+    name: str = "almighty.effector.destroy"
+    description: str = "Remove a target from the scenario. Always high-stakes (human review)."
+    args_schema: type[BaseModel] = DestroyArgs
+
+    def _build_validator_params(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, DestroyArgs)
+        return {
+            "range_m": args.range_m,
+            "time_of_flight_s": args.time_of_flight_s,
+            "dispersion_ellipse_a_m": args.dispersion_ellipse_a_m,
+            "dispersion_ellipse_b_m": args.dispersion_ellipse_b_m,
+        }
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, DestroyArgs)
+        return {
+            "target_entity_id": str(args.target_entity_id),
+            "weapon_system": args.weapon_system,
+            "volume_count": args.volume_count,
+            "justification": args.justification,
+            "range_m": args.range_m,
+            "time_of_flight_s": args.time_of_flight_s,
+            # Marker for downstream WS-405 adjudicator to flag human_required.
+            "stake": "high",
+        }

--- a/agents/tools/src/almighty_officer_tools/effector/disable.py
+++ b/agents/tools/src/almighty_officer_tools/effector/disable.py
@@ -1,0 +1,77 @@
+"""Effector.disable — render a target non-functional, method-dependent.
+
+Per WS-105:
+  KINETIC -> indirect_fire_arc artifact, target enters 'disabled'.
+  EW      -> jamming_circle artifact (borrows Communicator.jam capability).
+  CYBER   -> non-spatial; no artifact, no validator call.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from ..base import OfficerToolBase
+
+DisableMethod = Literal["KINETIC", "EW", "CYBER"]
+
+_FAMILY_BY_METHOD: dict[DisableMethod, str | None] = {
+    "KINETIC": "indirect_fire_arc",
+    "EW": "jamming_circle",
+    "CYBER": None,
+}
+
+
+class DisableArgs(BaseModel):
+    target_entity_id: UUID
+    method: DisableMethod
+    weapon_system: str = Field(min_length=1)
+    intensity: float | None = Field(default=None, ge=0)
+    # Validator params per method; defaults are reasonable midpoints. Real
+    # callers (WS-403/404) should supply method-appropriate values.
+    range_m: float = Field(gt=0, default=10_000.0)
+    time_of_flight_s: float = Field(ge=0, default=10.0)
+    dispersion_ellipse_a_m: float = Field(gt=0, default=50.0)
+    dispersion_ellipse_b_m: float = Field(gt=0, default=50.0)
+    radius_m: float = Field(gt=0, default=2_000.0)
+    power_w: float = Field(gt=0, default=200.0)
+
+
+class DisableTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "EFFECTOR"
+    VERB: ClassVar[str] = "disable"
+    EFFECT_FAMILY: ClassVar[str | None] = None  # method-dependent
+
+    name: str = "almighty.effector.disable"
+    description: str = "Render a target non-functional via KINETIC, EW, or CYBER method."
+    args_schema: type[BaseModel] = DisableArgs
+
+    def _effect_family_for(self, args: BaseModel) -> str | None:
+        assert isinstance(args, DisableArgs)
+        return _FAMILY_BY_METHOD[args.method]
+
+    def _build_validator_params(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, DisableArgs)
+        family = _FAMILY_BY_METHOD[args.method]
+        if family == "indirect_fire_arc":
+            return {
+                "range_m": args.range_m,
+                "time_of_flight_s": args.time_of_flight_s,
+                "dispersion_ellipse_a_m": args.dispersion_ellipse_a_m,
+                "dispersion_ellipse_b_m": args.dispersion_ellipse_b_m,
+            }
+        if family == "jamming_circle":
+            return {"radius_m": args.radius_m, "power_w": args.power_w}
+        # CYBER -> no validator call.
+        raise AssertionError(f"unreachable: family={family}")
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, DisableArgs)
+        return {
+            "target_entity_id": str(args.target_entity_id),
+            "method": args.method,
+            "weapon_system": args.weapon_system,
+            "intensity": args.intensity,
+        }

--- a/agents/tools/src/almighty_officer_tools/effector/engage.py
+++ b/agents/tools/src/almighty_officer_tools/effector/engage.py
@@ -1,0 +1,85 @@
+"""Effector.engage — apply effect to a target.
+
+For v1, all effector tools route to the `indirect_fire_arc` family for
+the validator gate (templates for direct-fire are out of WS-201 scope).
+The verb-distinguishing data lives on the kernel event payload.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+from ..base import OfficerToolBase
+
+EngageIntent = Literal["NEUTRALIZE", "SUPPRESS_AND_HOLD", "MARKER"]
+
+
+class EngageArgs(BaseModel):
+    weapon_system: str = Field(min_length=1)
+    volume_count: int = Field(ge=1)
+    target_entity_id: UUID | None = None
+    target_lat_deg: float | None = Field(default=None, ge=-90, le=90)
+    target_lon_deg: float | None = Field(default=None, ge=-180, le=180)
+    target_alt_m: float | None = None
+    intent: EngageIntent = "NEUTRALIZE"
+    range_m: float = Field(gt=0)
+    time_of_flight_s: float = Field(ge=0)
+    dispersion_ellipse_a_m: float = Field(gt=0, default=50.0)
+    dispersion_ellipse_b_m: float = Field(gt=0, default=50.0)
+
+    @model_validator(mode="after")
+    def _target_xor(self) -> "EngageArgs":
+        has_entity = self.target_entity_id is not None
+        has_coord = (
+            self.target_lat_deg is not None
+            and self.target_lon_deg is not None
+            and self.target_alt_m is not None
+        )
+        if has_entity == has_coord:
+            raise ValueError(
+                "engage requires exactly one of target_entity_id or "
+                "(target_lat_deg, target_lon_deg, target_alt_m)"
+            )
+        return self
+
+
+class EngageTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "EFFECTOR"
+    VERB: ClassVar[str] = "engage"
+    EFFECT_FAMILY: ClassVar[str | None] = "indirect_fire_arc"
+
+    name: str = "almighty.effector.engage"
+    description: str = "Apply effect to a target."
+    args_schema: type[BaseModel] = EngageArgs
+
+    def _build_validator_params(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, EngageArgs)
+        return {
+            "range_m": args.range_m,
+            "time_of_flight_s": args.time_of_flight_s,
+            "dispersion_ellipse_a_m": args.dispersion_ellipse_a_m,
+            "dispersion_ellipse_b_m": args.dispersion_ellipse_b_m,
+        }
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, EngageArgs)
+        return {
+            "weapon_system": args.weapon_system,
+            "volume_count": args.volume_count,
+            "target_entity_id": str(args.target_entity_id) if args.target_entity_id else None,
+            "target_coordinate": (
+                {
+                    "lat_deg": args.target_lat_deg,
+                    "lon_deg": args.target_lon_deg,
+                    "alt_m": args.target_alt_m,
+                }
+                if args.target_entity_id is None
+                else None
+            ),
+            "intent": args.intent,
+            "range_m": args.range_m,
+            "time_of_flight_s": args.time_of_flight_s,
+        }

--- a/agents/tools/src/almighty_officer_tools/effector/suppress.py
+++ b/agents/tools/src/almighty_officer_tools/effector/suppress.py
@@ -1,0 +1,66 @@
+"""Effector.suppress — apply effect to deny use of an area or asset."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+from ..base import OfficerToolBase
+
+
+class SuppressArgs(BaseModel):
+    weapon_system: str = Field(min_length=1)
+    duration_s: float = Field(gt=0)
+    rate_per_min: float = Field(gt=0)
+    target_lat_deg: float = Field(ge=-90, le=90)
+    target_lon_deg: float = Field(ge=-180, le=180)
+    target_alt_m: float = 0.0
+    target_polygon: list[list[float]] | None = None
+    range_m: float = Field(gt=0)
+    time_of_flight_s: float = Field(ge=0)
+    dispersion_ellipse_a_m: float = Field(gt=0, default=80.0)
+    dispersion_ellipse_b_m: float = Field(gt=0, default=80.0)
+
+    @model_validator(mode="after")
+    def _polygon_shape(self) -> "SuppressArgs":
+        if self.target_polygon is not None and len(self.target_polygon) < 3:
+            raise ValueError("target_polygon, when set, must have ≥ 3 vertices")
+        return self
+
+
+class SuppressTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "EFFECTOR"
+    VERB: ClassVar[str] = "suppress"
+    EFFECT_FAMILY: ClassVar[str | None] = "indirect_fire_arc"
+
+    name: str = "almighty.effector.suppress"
+    description: str = "Apply effect to deny use of an area without destroying it."
+    args_schema: type[BaseModel] = SuppressArgs
+
+    def _build_validator_params(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, SuppressArgs)
+        return {
+            "range_m": args.range_m,
+            "time_of_flight_s": args.time_of_flight_s,
+            "dispersion_ellipse_a_m": args.dispersion_ellipse_a_m,
+            "dispersion_ellipse_b_m": args.dispersion_ellipse_b_m,
+        }
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, SuppressArgs)
+        return {
+            "weapon_system": args.weapon_system,
+            "mode": "suppression",
+            "duration_s": args.duration_s,
+            "rate_per_min": args.rate_per_min,
+            "target_coordinate": {
+                "lat_deg": args.target_lat_deg,
+                "lon_deg": args.target_lon_deg,
+                "alt_m": args.target_alt_m,
+            },
+            "target_polygon": args.target_polygon,
+            "range_m": args.range_m,
+            "time_of_flight_s": args.time_of_flight_s,
+        }

--- a/agents/tools/src/almighty_officer_tools/mover/__init__.py
+++ b/agents/tools/src/almighty_officer_tools/mover/__init__.py
@@ -1,0 +1,6 @@
+from .assume_posture import AssumePostureTool
+from .follow_route import FollowRouteTool
+from .halt import HaltTool
+from .move_to import MoveToTool
+
+__all__ = ["MoveToTool", "FollowRouteTool", "HaltTool", "AssumePostureTool"]

--- a/agents/tools/src/almighty_officer_tools/mover/assume_posture.py
+++ b/agents/tools/src/almighty_officer_tools/mover/assume_posture.py
@@ -1,0 +1,36 @@
+"""Mover.assume_posture — change tactical posture.
+
+Validator-side: the posture-transition matrix is enforced by the
+capability-profile validator (WS-202 v2; not in scope here). v1 commits
+the event and lets the adjudicator (WS-405) reject if the target posture
+is not in the profile's `posture_transitions`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel, Field
+
+from ..base import OfficerToolBase
+
+Posture = Literal["HALTED", "MOUNTED", "DISMOUNTED", "DUG_IN", "ALERT", "REST"]
+
+
+class AssumePostureArgs(BaseModel):
+    posture: Posture
+    transition_s: float | None = Field(default=None, gt=0)
+
+
+class AssumePostureTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "MOVER"
+    VERB: ClassVar[str] = "assume_posture"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.mover.assume_posture"
+    description: str = "Change the entity's tactical posture."
+    args_schema: type[BaseModel] = AssumePostureArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, AssumePostureArgs)
+        return {"posture": args.posture, "transition_s": args.transition_s}

--- a/agents/tools/src/almighty_officer_tools/mover/follow_route.py
+++ b/agents/tools/src/almighty_officer_tools/mover/follow_route.py
@@ -1,0 +1,45 @@
+"""Mover.follow_route — move along a sequence of waypoints."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, Field, model_validator
+
+from ..base import OfficerToolBase
+
+
+class Waypoint(BaseModel):
+    lat_deg: float = Field(ge=-90, le=90)
+    lon_deg: float = Field(ge=-180, le=180)
+    alt_m: float
+
+
+class FollowRouteArgs(BaseModel):
+    waypoints: list[Waypoint]
+    speed_mps: float | None = Field(default=None, gt=0)
+    loop: bool = False
+
+    @model_validator(mode="after")
+    def _non_empty(self) -> "FollowRouteArgs":
+        if not self.waypoints:
+            raise ValueError("follow_route requires waypoints length >= 1")
+        return self
+
+
+class FollowRouteTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "MOVER"
+    VERB: ClassVar[str] = "follow_route"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.mover.follow_route"
+    description: str = "Move along a sequence of waypoints."
+    args_schema: type[BaseModel] = FollowRouteArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, FollowRouteArgs)
+        return {
+            "waypoints": [w.model_dump() for w in args.waypoints],
+            "speed_mps": args.speed_mps,
+            "loop": args.loop,
+        }

--- a/agents/tools/src/almighty_officer_tools/mover/halt.py
+++ b/agents/tools/src/almighty_officer_tools/mover/halt.py
@@ -1,0 +1,27 @@
+"""Mover.halt — stop motion immediately. No parameters."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import BaseModel
+
+from ..base import OfficerToolBase
+
+
+class HaltArgs(BaseModel):
+    pass
+
+
+class HaltTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "MOVER"
+    VERB: ClassVar[str] = "halt"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.mover.halt"
+    description: str = "Stop motion immediately."
+    args_schema: type[BaseModel] = HaltArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        del args
+        return {}

--- a/agents/tools/src/almighty_officer_tools/mover/move_to.py
+++ b/agents/tools/src/almighty_officer_tools/mover/move_to.py
@@ -1,0 +1,39 @@
+"""Mover.move_to — move to a single coordinate.
+
+Per WS-105 and the better-late-than-never doc: Mover verbs emit no
+spatial artifacts. No validator call.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, Field
+
+from ..base import OfficerToolBase
+
+
+class MoveToArgs(BaseModel):
+    target_lat_deg: float = Field(ge=-90, le=90)
+    target_lon_deg: float = Field(ge=-180, le=180)
+    target_alt_m: float
+    speed_mps: float | None = Field(default=None, gt=0)
+
+
+class MoveToTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "MOVER"
+    VERB: ClassVar[str] = "move_to"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.mover.move_to"
+    description: str = "Move to a single coordinate."
+    args_schema: type[BaseModel] = MoveToArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, MoveToArgs)
+        return {
+            "target_lat_deg": args.target_lat_deg,
+            "target_lon_deg": args.target_lon_deg,
+            "target_alt_m": args.target_alt_m,
+            "speed_mps": args.speed_mps,
+        }

--- a/agents/tools/src/almighty_officer_tools/registry.py
+++ b/agents/tools/src/almighty_officer_tools/registry.py
@@ -1,0 +1,59 @@
+"""Registry helper — instantiate all 20 officer tools for a given context.
+
+WS-403 / WS-404 / WS-405 will typically construct the subset of tools
+their crew agents need (e.g., a Sensor-only S2 agent gets only the four
+Sensor tools). For tests and for crews that want the full 20-verb
+toolbox, ``build_all_tools`` returns a name-keyed dict.
+"""
+
+from __future__ import annotations
+
+from .base import OfficerToolBase
+from .commander import (
+    DelegateTool,
+    EscalateTool,
+    IssueOrderTool,
+    RequestSupportTool,
+)
+from .communicator import JamTool, RelayTool, ReportTool, SendTool
+from .context import OfficerToolContext
+from .effector import DestroyTool, DisableTool, EngageTool, SuppressTool
+from .mover import AssumePostureTool, FollowRouteTool, HaltTool, MoveToTool
+from .sensor import ClassifyTool, DetectTool, LoseTrackTool, TrackTool
+
+ALL_TOOL_CLASSES: list[type[OfficerToolBase]] = [
+    # Sensor
+    DetectTool,
+    TrackTool,
+    ClassifyTool,
+    LoseTrackTool,
+    # Effector
+    EngageTool,
+    SuppressTool,
+    DestroyTool,
+    DisableTool,
+    # Mover
+    MoveToTool,
+    FollowRouteTool,
+    HaltTool,
+    AssumePostureTool,
+    # Communicator
+    SendTool,
+    RelayTool,
+    JamTool,
+    ReportTool,
+    # Commander
+    IssueOrderTool,
+    RequestSupportTool,
+    DelegateTool,
+    EscalateTool,
+]
+
+
+def build_all_tools(ctx: OfficerToolContext) -> dict[str, OfficerToolBase]:
+    """Instantiate one tool per verb, all bound to ``ctx``.
+
+    Returned dict is keyed on the verb name (e.g. ``"detect"``,
+    ``"engage"``) so callers can pluck individual tools by name.
+    """
+    return {cls.VERB: cls(ctx=ctx) for cls in ALL_TOOL_CLASSES}

--- a/agents/tools/src/almighty_officer_tools/sensor/__init__.py
+++ b/agents/tools/src/almighty_officer_tools/sensor/__init__.py
@@ -1,0 +1,6 @@
+from .classify import ClassifyTool
+from .detect import DetectTool
+from .lose_track import LoseTrackTool
+from .track import TrackTool
+
+__all__ = ["DetectTool", "TrackTool", "ClassifyTool", "LoseTrackTool"]

--- a/agents/tools/src/almighty_officer_tools/sensor/classify.py
+++ b/agents/tools/src/almighty_officer_tools/sensor/classify.py
@@ -1,0 +1,48 @@
+"""Sensor.classify — refine a track into a typed classification.
+
+Always emits a `keyhole_footprint` artifact (per WS-105 § Sensor.classify
+and WS-108 § 4.9).
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from ..base import OfficerToolBase
+
+
+class ClassifyArgs(BaseModel):
+    track_id: UUID
+    classification_label: str = Field(min_length=1)
+    confidence: float = Field(ge=0.0, le=1.0)
+    dwell_s: float = Field(gt=0)
+
+
+class ClassifyTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "SENSOR"
+    VERB: ClassVar[str] = "classify"
+    EFFECT_FAMILY: ClassVar[str | None] = "keyhole_footprint"
+
+    name: str = "almighty.sensor.classify"
+    description: str = "Refine a track into a typed classification."
+    args_schema: type[BaseModel] = ClassifyArgs
+
+    def _build_validator_params(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, ClassifyArgs)
+        return {
+            # Tighter footprint scales loosely with dwell; clamp to template
+            # range. Real polygon synthesis is a render-time concern.
+            "polygon_area_m2": min(50_000.0, max(500.0, args.dwell_s * 100.0)),
+        }
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, ClassifyArgs)
+        return {
+            "track_id": str(args.track_id),
+            "classification_label": args.classification_label,
+            "confidence": args.confidence,
+            "dwell_s": args.dwell_s,
+        }

--- a/agents/tools/src/almighty_officer_tools/sensor/detect.py
+++ b/agents/tools/src/almighty_officer_tools/sensor/detect.py
@@ -1,0 +1,90 @@
+"""Sensor.detect — identify a previously unobserved target.
+
+Spatial artifact emitted depends on modality, per WS-108 § 6.1:
+
+  EO_IR        -> none in v1 (no template)
+  RF           -> ew_cone
+  RADAR        -> radar_fan
+  ACOUSTIC     -> masint_cell
+  SEISMIC      -> masint_cell
+  MASINT_MULTI -> masint_cell
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from ..base import OfficerToolBase
+
+Modality = Literal["EO_IR", "RF", "RADAR", "ACOUSTIC", "SEISMIC", "MASINT_MULTI"]
+
+_FAMILY_BY_MODALITY: dict[Modality, str | None] = {
+    "EO_IR": None,
+    "RF": "ew_cone",
+    "RADAR": "radar_fan",
+    "ACOUSTIC": "masint_cell",
+    "SEISMIC": "masint_cell",
+    "MASINT_MULTI": "masint_cell",
+}
+
+
+class DetectArgs(BaseModel):
+    target_entity_id: UUID
+    modality: Modality
+    confidence: float = Field(ge=0.0, le=1.0)
+    range_m: float = Field(gt=0)
+    czml_template: str | None = None
+
+
+class DetectTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "SENSOR"
+    VERB: ClassVar[str] = "detect"
+    # EFFECT_FAMILY resolved per-call from modality.
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.sensor.detect"
+    description: str = "Identify a previously unobserved target."
+    args_schema: type[BaseModel] = DetectArgs
+
+    def _effect_family_for(self, args: BaseModel) -> str | None:
+        assert isinstance(args, DetectArgs)
+        return _FAMILY_BY_MODALITY[args.modality]
+
+    def _build_validator_params(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, DetectArgs)
+        family = _FAMILY_BY_MODALITY[args.modality]
+        # Each family expects different params; keep this minimal — the
+        # validator only checks template `capability_constraints` keys.
+        if family == "ew_cone":
+            return {
+                "azimuth_deg": 0.0,
+                "beamwidth_deg": 30.0,
+                "effective_range_m": args.range_m,
+            }
+        if family == "radar_fan":
+            return {
+                "azimuth_deg": 0.0,
+                "sweep_arc_deg": 60.0,
+                "range_m": args.range_m,
+            }
+        if family == "masint_cell":
+            return {
+                "polygon_area_m2": 50_000.0,
+                "dwell_s": 600.0,
+            }
+        # EO_IR has no validator path — _effect_family_for returned None,
+        # so this method is never called.
+        raise AssertionError(f"unreachable: family={family}")
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, DetectArgs)
+        return {
+            "target_entity_id": str(args.target_entity_id),
+            "modality": args.modality,
+            "confidence": args.confidence,
+            "range_m": args.range_m,
+            "czml_template": args.czml_template,
+        }

--- a/agents/tools/src/almighty_officer_tools/sensor/lose_track.py
+++ b/agents/tools/src/almighty_officer_tools/sensor/lose_track.py
@@ -1,0 +1,36 @@
+"""Sensor.lose_track — close an open track.
+
+Per WS-105: no spatial artifact; the track simply closes. No validator.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from ..base import OfficerToolBase
+
+LossReason = Literal[
+    "OUT_OF_RANGE", "OCCLUDED", "JAMMED", "DECONFLICTED", "DESTROYED_TARGET", "OPERATOR_REQUEST"
+]
+
+
+class LoseTrackArgs(BaseModel):
+    track_id: UUID
+    reason: LossReason
+
+
+class LoseTrackTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "SENSOR"
+    VERB: ClassVar[str] = "lose_track"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.sensor.lose_track"
+    description: str = "End an open track."
+    args_schema: type[BaseModel] = LoseTrackArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, LoseTrackArgs)
+        return {"track_id": str(args.track_id), "reason": args.reason}

--- a/agents/tools/src/almighty_officer_tools/sensor/track.py
+++ b/agents/tools/src/almighty_officer_tools/sensor/track.py
@@ -1,0 +1,40 @@
+"""Sensor.track — maintain a recurring observation on a previously detected target.
+
+Per WS-105 / WS-108: track has no spatial artifact of its own; it
+extends the parent detection's lifetime. No validator call.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+from ..base import OfficerToolBase
+
+
+class TrackArgs(BaseModel):
+    target_entity_id: UUID
+    update_rate_hz: float = Field(gt=0)
+    track_id: UUID | None = None
+    lifetime_s: float | None = Field(default=None, gt=0)
+
+
+class TrackTool(OfficerToolBase):
+    OFFICER_TYPE: ClassVar[str] = "SENSOR"
+    VERB: ClassVar[str] = "track"
+    EFFECT_FAMILY: ClassVar[str | None] = None
+
+    name: str = "almighty.sensor.track"
+    description: str = "Maintain a recurring observation on a previously detected target."
+    args_schema: type[BaseModel] = TrackArgs
+
+    def _build_event_payload(self, args: BaseModel) -> dict[str, Any]:
+        assert isinstance(args, TrackArgs)
+        return {
+            "target_entity_id": str(args.target_entity_id),
+            "track_id": str(args.track_id or uuid4()),
+            "update_rate_hz": args.update_rate_hz,
+            "lifetime_s": args.lifetime_s,
+        }

--- a/agents/tools/tests/conftest.py
+++ b/agents/tools/tests/conftest.py
@@ -1,0 +1,91 @@
+"""Test fixtures.
+
+Loads the WS-107 capability profiles from the repo and constructs an
+OfficerToolContext bound to a real :class:`NamespacedDag` and the real
+WS-202 :class:`Validator`. No mocks of those: when a tool fires, it
+genuinely commits to the in-memory DAG and genuinely consults the
+validator. That keeps the contract honest end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from almighty_czml_validator import Validator
+from almighty_kernel.dag import NamespacedDag
+
+from almighty_officer_tools import OfficerToolContext, build_all_tools
+from almighty_officer_tools.base import OfficerToolBase
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROFILES_DIR = REPO_ROOT / "kernel" / "capability-profiles"
+
+
+def _load_profile(name: str) -> dict:
+    with (PROFILES_DIR / f"{name}.json").open() as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="session")
+def us_bct_profile() -> dict:
+    return _load_profile("us-bct")
+
+
+@pytest.fixture(scope="session")
+def peer_profile() -> dict:
+    return _load_profile("peer")
+
+
+@pytest.fixture(scope="session")
+def hybrid_profile() -> dict:
+    return _load_profile("hybrid-irregular")
+
+
+@pytest.fixture()
+def kernel_dag() -> NamespacedDag:
+    return NamespacedDag()
+
+
+@pytest.fixture(scope="session")
+def validator() -> Validator:
+    return Validator()
+
+
+@pytest.fixture()
+def context_factory(kernel_dag: NamespacedDag, validator: Validator):
+    """Returns a callable to mint an OfficerToolContext bound to the
+    fixture's DAG + validator. Tests pass in the profile they want."""
+
+    def _make(
+        profile: dict,
+        *,
+        turn: int = 0,
+        tenant_id: UUID | None = None,
+        scenario_id: UUID | None = None,
+        agent_entity_id: UUID | None = None,
+    ) -> OfficerToolContext:
+        return OfficerToolContext(
+            tenant_id=tenant_id or UUID("11111111-1111-4111-8111-111111111111"),
+            scenario_id=scenario_id or UUID("22222222-2222-4222-8222-222222222222"),
+            turn=turn,
+            agent_entity_id=agent_entity_id or uuid4(),
+            capability_profile=profile,
+            kernel_dag=kernel_dag,
+            validator=validator,
+        )
+
+    return _make
+
+
+@pytest.fixture()
+def all_tools_us_bct(context_factory, us_bct_profile) -> dict[str, OfficerToolBase]:
+    return build_all_tools(context_factory(us_bct_profile))
+
+
+@pytest.fixture()
+def all_tools_peer(context_factory, peer_profile) -> dict[str, OfficerToolBase]:
+    return build_all_tools(context_factory(peer_profile))

--- a/agents/tools/tests/test_base.py
+++ b/agents/tools/tests/test_base.py
@@ -1,0 +1,54 @@
+"""Tests for the base flow: capability gate fires before validator,
+unknown verb raises ToolError without touching the validator, etc."""
+
+from __future__ import annotations
+
+import pytest
+
+from almighty_officer_tools import ToolError, build_all_tools
+
+from almighty_officer_tools.registry import ALL_TOOL_CLASSES
+
+
+def test_all_twenty_tools_built(us_bct_profile, context_factory):
+    tools = build_all_tools(context_factory(us_bct_profile))
+    assert len(tools) == 20
+    # Verb names match WS-105 lock list.
+    expected = {
+        "detect", "track", "classify", "lose_track",
+        "engage", "suppress", "destroy", "disable",
+        "move_to", "follow_route", "halt", "assume_posture",
+        "send", "relay", "jam", "report",
+        "issue_order", "request_support", "delegate", "escalate",
+    }
+    assert set(tools.keys()) == expected
+
+
+def test_capability_gate_blocks_missing_verb(context_factory, us_bct_profile):
+    """us-bct.json has no 'jam' verb -> JamTool must reject before
+    touching the validator. Confirms the gate fires."""
+    assert "jam" not in us_bct_profile["action_verbs_available"]
+    tools = build_all_tools(context_factory(us_bct_profile))
+    with pytest.raises(ToolError) as exc:
+        tools["jam"]._run(
+            target_polygon=[[36.18, -86.78], [36.19, -86.77], [36.17, -86.76]],
+            power_w=100.0,
+            band="VHF",
+            duration_s=60.0,
+        )
+    assert "capability gate" in exc.value.reason
+    assert "'jam'" in exc.value.reason
+
+
+def test_tool_classes_unique_verbs():
+    """Sanity: no two tool classes share a VERB."""
+    verbs = [c.VERB for c in ALL_TOOL_CLASSES]
+    assert len(verbs) == len(set(verbs)), "duplicate VERB found among tool classes"
+
+
+def test_all_tools_subclass_basetool():
+    """Sanity: all tool classes inherit crewai.tools.BaseTool indirectly."""
+    from crewai.tools import BaseTool
+
+    for cls in ALL_TOOL_CLASSES:
+        assert issubclass(cls, BaseTool), f"{cls.__name__} must subclass crewai BaseTool"

--- a/agents/tools/tests/test_commander.py
+++ b/agents/tools/tests/test_commander.py
@@ -1,0 +1,94 @@
+"""Tests for the four Commander verbs."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from almighty_officer_tools import ToolError
+
+
+def test_issue_order(all_tools_us_bct):
+    out = all_tools_us_bct["issue_order"]._run(
+        order_type="MOVE",
+        order_payload={"waypoint": [36.20, -86.78]},
+        to_echelon="COMPANY",
+    )
+    assert out["verb"] == "issue_order"
+    assert out["validator"] == "skipped"
+
+
+def test_request_support_fires_requires_coord(all_tools_us_bct):
+    """FIRES support without target coord must fail at the args schema."""
+    with pytest.raises(Exception):  # pydantic ValidationError surfaces here
+        all_tools_us_bct["request_support"]._run(
+            support_type="FIRES",
+            justification="enemy bunker on east bank",
+            priority="HIGH",
+        )
+
+
+def test_request_support_fires_with_coord(all_tools_us_bct):
+    out = all_tools_us_bct["request_support"]._run(
+        support_type="FIRES",
+        justification="enemy bunker on east bank",
+        priority="HIGH",
+        target_lat_deg=36.18,
+        target_lon_deg=-86.78,
+        target_alt_m=170.0,
+    )
+    assert out["validator"] == "skipped"
+
+
+def test_delegate_subset_check(all_tools_us_bct):
+    """Cannot delegate verbs the agent doesn't itself have."""
+    with pytest.raises(ToolError) as exc:
+        all_tools_us_bct["delegate"]._run(
+            to_entity_id=uuid4(),
+            delegated_verbs=["jam"],  # us-bct has no 'jam'
+            ttl_turns=2,
+        )
+    assert "cannot delegate verbs not in own authority" in exc.value.reason
+
+
+def test_delegate_happy(all_tools_us_bct):
+    out = all_tools_us_bct["delegate"]._run(
+        to_entity_id=uuid4(),
+        delegated_verbs=["move_to", "engage"],
+        ttl_turns=3,
+    )
+    assert out["verb"] == "delegate"
+    assert out["validator"] == "skipped"
+
+
+def test_escalate_strictly_higher(all_tools_us_bct):
+    """us-bct.commander.echelon=BATTALION; BRIGADE > BATTALION OK."""
+    out = all_tools_us_bct["escalate"]._run(
+        reason="prep'd to lose comms with BN HQ",
+        severity="PRIORITY",
+        to_echelon="BRIGADE",
+    )
+    assert out["verb"] == "escalate"
+
+
+def test_escalate_sideways_rejected(all_tools_us_bct):
+    """BATTALION -> BATTALION must reject; same rank is not strictly higher."""
+    with pytest.raises(ToolError) as exc:
+        all_tools_us_bct["escalate"]._run(
+            reason="trying to bypass override",
+            severity="ROUTINE",
+            to_echelon="BATTALION",
+        )
+    assert "not strictly higher" in exc.value.reason
+
+
+def test_escalate_downward_rejected(all_tools_us_bct):
+    """BATTALION -> COMPANY rejects."""
+    with pytest.raises(ToolError) as exc:
+        all_tools_us_bct["escalate"]._run(
+            reason="downward escalate",
+            severity="ROUTINE",
+            to_echelon="COMPANY",
+        )
+    assert "not strictly higher" in exc.value.reason

--- a/agents/tools/tests/test_communicator.py
+++ b/agents/tools/tests/test_communicator.py
@@ -1,0 +1,78 @@
+"""Tests for the four Communicator verbs."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from almighty_officer_tools import ToolError
+
+
+def test_send_no_validator(all_tools_us_bct):
+    out = all_tools_us_bct["send"]._run(
+        channel="VHF",
+        message_payload={"line": "test"},
+        recipient_role="BATTALION_S3",
+    )
+    assert out["verb"] == "send"
+    assert out["validator"] == "skipped"
+
+
+def test_relay_non_airborne_no_corridor(all_tools_us_bct):
+    """us-bct has advertise_corridor=false. Even if relay is_airborne=True,
+    no uas_corridor validator path fires."""
+    out = all_tools_us_bct["relay"]._run(
+        source_entity_id=uuid4(),
+        recipient_entity_id=uuid4(),
+        channel="VHF",
+        is_airborne=True,
+    )
+    assert out["validator"] == "skipped"
+
+
+def test_relay_airborne_with_corridor(all_tools_peer):
+    """peer.json has advertise_corridor=true AND uas_corridor in
+    effect_parameter_ranges + 'relay' in action_verbs_available."""
+    out = all_tools_peer["relay"]._run(
+        source_entity_id=uuid4(),
+        recipient_entity_id=uuid4(),
+        channel="VHF",
+        is_airborne=True,
+    )
+    assert out["validator"] == "accepted"
+
+
+def test_jam_happy_on_peer(all_tools_peer):
+    """peer.json has 'jam' verb + jamming_circle ranges + L band."""
+    out = all_tools_peer["jam"]._run(
+        target_polygon=[[36.18, -86.78], [36.19, -86.77], [36.17, -86.76]],
+        power_w=500.0,
+        band="L",
+        duration_s=120.0,
+        radius_m=2_000.0,
+    )
+    assert out["validator"] == "accepted"
+
+
+def test_jam_out_of_range_rejects(all_tools_peer):
+    """peer jamming_circle.power_w max is 1500; 5000 must reject."""
+    with pytest.raises(ToolError) as exc:
+        all_tools_peer["jam"]._run(
+            target_polygon=[[36.18, -86.78], [36.19, -86.77], [36.17, -86.76]],
+            power_w=5_000.0,
+            band="L",
+            duration_s=60.0,
+            radius_m=2_000.0,
+        )
+    assert "validator rejected 'jam'" in exc.value.reason
+    assert "power_w" in exc.value.reason
+
+
+def test_report_no_validator(all_tools_us_bct):
+    out = all_tools_us_bct["report"]._run(
+        report_type="SITREP",
+        report_payload={"line1": "no contact"},
+        to_echelon="BRIGADE",
+    )
+    assert out["validator"] == "skipped"

--- a/agents/tools/tests/test_effector.py
+++ b/agents/tools/tests/test_effector.py
@@ -1,0 +1,107 @@
+"""Tests for the four Effector verbs."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from almighty_officer_tools import ToolError
+
+
+def test_engage_happy(all_tools_us_bct):
+    out = all_tools_us_bct["engage"]._run(
+        target_entity_id=uuid4(),
+        weapon_system="notional.indirect.medium",
+        volume_count=4,
+        intent="NEUTRALIZE",
+        range_m=10_000.0,
+        time_of_flight_s=25.0,
+    )
+    assert out["verb"] == "engage"
+    assert out["validator"] == "accepted"
+
+
+def test_engage_out_of_range_rejects(all_tools_us_bct):
+    """us-bct indirect_fire_arc.range_m max is 25000; 50000 must reject."""
+    with pytest.raises(ToolError) as exc:
+        all_tools_us_bct["engage"]._run(
+            target_entity_id=uuid4(),
+            weapon_system="notional.indirect.medium",
+            volume_count=1,
+            range_m=50_000.0,
+            time_of_flight_s=25.0,
+        )
+    assert "validator rejected 'engage'" in exc.value.reason
+    assert "range_m" in exc.value.reason
+
+
+def test_suppress_happy(all_tools_us_bct):
+    out = all_tools_us_bct["suppress"]._run(
+        weapon_system="notional.indirect.medium",
+        duration_s=120.0,
+        rate_per_min=4.0,
+        target_lat_deg=36.18,
+        target_lon_deg=-86.78,
+        range_m=8_000.0,
+        time_of_flight_s=20.0,
+    )
+    assert out["validator"] == "accepted"
+
+
+def test_destroy_carries_high_stake(all_tools_us_bct, kernel_dag):
+    out = all_tools_us_bct["destroy"]._run(
+        target_entity_id=uuid4(),
+        weapon_system="notional.indirect.medium",
+        volume_count=2,
+        justification="confirmed enemy command vehicle, no civilians within 500 m",
+        range_m=12_000.0,
+        time_of_flight_s=30.0,
+    )
+    assert out["verb"] == "destroy"
+    assert out["validator"] == "accepted"
+    # The committed event payload should carry the stake marker the
+    # adjudicator (WS-405) reads.
+    events = list(kernel_dag._index.values())
+    # The committed event is the one we just added; assert at least one
+    # destroy event exists with stake='high'.
+    payload_stakes = [
+        e.payload.get("stake")
+        for _, e in events
+        if e.name == "destroy"
+    ]
+    assert "high" in payload_stakes
+
+
+def test_disable_kinetic_uses_indirect_fire(all_tools_peer):
+    """peer.json has 'disable' verb. KINETIC method routes to indirect_fire_arc."""
+    out = all_tools_peer["disable"]._run(
+        target_entity_id=uuid4(),
+        method="KINETIC",
+        weapon_system="notional.indirect.medium",
+        range_m=8_000.0,
+        time_of_flight_s=20.0,
+    )
+    assert out["validator"] == "accepted"
+
+
+def test_disable_cyber_no_validator(all_tools_peer):
+    """CYBER method -> no spatial artifact -> validator skipped."""
+    out = all_tools_peer["disable"]._run(
+        target_entity_id=uuid4(),
+        method="CYBER",
+        weapon_system="notional.cyber.placeholder",
+    )
+    assert out["validator"] == "skipped"
+
+
+def test_us_bct_lacks_disable_verb(us_bct_profile, all_tools_us_bct):
+    """Confirm capability gate fires when profile lacks the verb."""
+    assert "disable" not in us_bct_profile["action_verbs_available"]
+    with pytest.raises(ToolError) as exc:
+        all_tools_us_bct["disable"]._run(
+            target_entity_id=uuid4(),
+            method="KINETIC",
+            weapon_system="notional.indirect.medium",
+        )
+    assert "capability gate" in exc.value.reason

--- a/agents/tools/tests/test_mover.py
+++ b/agents/tools/tests/test_mover.py
@@ -1,0 +1,37 @@
+"""Tests for the four Mover verbs. None call the validator (no spatial artifacts)."""
+
+from __future__ import annotations
+
+
+def test_move_to(all_tools_us_bct):
+    out = all_tools_us_bct["move_to"]._run(
+        target_lat_deg=36.20,
+        target_lon_deg=-86.78,
+        target_alt_m=170.0,
+    )
+    assert out["verb"] == "move_to"
+    assert out["validator"] == "skipped"
+
+
+def test_follow_route(all_tools_us_bct):
+    out = all_tools_us_bct["follow_route"]._run(
+        waypoints=[
+            {"lat_deg": 36.18, "lon_deg": -86.78, "alt_m": 165.0},
+            {"lat_deg": 36.19, "lon_deg": -86.77, "alt_m": 167.0},
+        ],
+        speed_mps=10.0,
+    )
+    assert out["verb"] == "follow_route"
+    assert out["validator"] == "skipped"
+
+
+def test_halt_no_args(all_tools_us_bct):
+    out = all_tools_us_bct["halt"]._run()
+    assert out["verb"] == "halt"
+    assert out["validator"] == "skipped"
+
+
+def test_assume_posture(all_tools_us_bct):
+    out = all_tools_us_bct["assume_posture"]._run(posture="DUG_IN")
+    assert out["verb"] == "assume_posture"
+    assert out["validator"] == "skipped"

--- a/agents/tools/tests/test_sensor.py
+++ b/agents/tools/tests/test_sensor.py
@@ -1,0 +1,76 @@
+"""Tests for the four Sensor verbs."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from almighty_officer_tools import ToolError
+
+
+def test_detect_radar_happy(all_tools_us_bct):
+    """detect with modality=RADAR -> radar_fan validator path; us-bct has both."""
+    out = all_tools_us_bct["detect"]._run(
+        target_entity_id=uuid4(),
+        modality="RADAR",
+        confidence=0.9,
+        range_m=10_000.0,
+    )
+    assert out["verb"] == "detect"
+    assert out["officer_type"] == "SENSOR"
+    assert out["validator"] == "accepted"
+
+
+def test_detect_eo_ir_no_validator(all_tools_us_bct):
+    """detect with modality=EO_IR -> no spatial artifact -> validator skipped."""
+    out = all_tools_us_bct["detect"]._run(
+        target_entity_id=uuid4(),
+        modality="EO_IR",
+        confidence=0.7,
+        range_m=2_000.0,
+    )
+    assert out["validator"] == "skipped"
+
+
+def test_detect_radar_out_of_range_rejects(all_tools_us_bct, us_bct_profile):
+    """range_m exceeding intersect(template, profile) -> validator reject."""
+    # us-bct radar_fan profile.range_m max is 50000; template max is 80000;
+    # intersect = 50000. 100000 should reject.
+    with pytest.raises(ToolError) as exc:
+        all_tools_us_bct["detect"]._run(
+            target_entity_id=uuid4(),
+            modality="RADAR",
+            confidence=0.9,
+            range_m=100_000.0,
+        )
+    assert "validator rejected 'detect'" in exc.value.reason
+    assert "range_m" in exc.value.reason
+
+
+def test_track_no_validator(all_tools_us_bct):
+    out = all_tools_us_bct["track"]._run(
+        target_entity_id=uuid4(),
+        update_rate_hz=2.0,
+    )
+    assert out["verb"] == "track"
+    assert out["validator"] == "skipped"
+
+
+def test_classify_uses_keyhole_footprint(all_tools_us_bct):
+    out = all_tools_us_bct["classify"]._run(
+        track_id=uuid4(),
+        classification_label="notional.air.uas.medium",
+        confidence=0.8,
+        dwell_s=30.0,
+    )
+    assert out["verb"] == "classify"
+    assert out["validator"] == "accepted"
+
+
+def test_lose_track_no_validator(all_tools_us_bct):
+    out = all_tools_us_bct["lose_track"]._run(
+        track_id=uuid4(),
+        reason="OUT_OF_RANGE",
+    )
+    assert out["validator"] == "skipped"


### PR DESCRIPTION
## Summary

Twenty CrewAI tools — one per WS-105 verb — each running the gate-then-validate-then-commit dance:

```
agent → tool._run(...) → capability gate → validator → kernel.commit()
```

Tools never mutate state directly. Every successful path commits a `KernelEvent` through `NamespacedDag.commit()`, never raw SQL — per the [better-late-than-never](docs/better-late-than-never.md) doc.

Closes #22.

## What it does (per the runbook prompt)

For every call, in order:

1. **Capability-verb gate.** If profile.action_verbs_available lacks this tool's `VERB`, raise `ToolError` immediately. The validator is **never** consulted — fast rejection per WS-105 / runbook §1093.
2. **Args validation** via Pydantic schema, plus per-verb extras (e.g., `delegate.delegated_verbs ⊆ own authority`, `escalate.to_echelon` strictly higher).
3. **Validator gate (CZML-emitting verbs only).** Build a params dict and call the in-process WS-202 `Validator`. Reject with `ToolError(reason)` on `accepted=False`.
4. **Kernel commit.** Build a `KernelEvent`, hand to `NamespacedDag.commit()`. Returns `{event_id, verb, officer_type, validator}`.

## Layout

```
agents/tools/
├── pyproject.toml                  (crewai 1.14, pydantic 2.6, editable deps on kernel + validator)
├── README.md                       (API contract, integration notes for WS-403/404/405)
├── src/almighty_officer_tools/
│   ├── context.py                  (OfficerToolContext, ToolError)
│   ├── base.py                     (OfficerToolBase: gate + dispatch + commit)
│   ├── registry.py                 (build_all_tools, ALL_TOOL_CLASSES)
│   ├── sensor/{detect,track,classify,lose_track}.py
│   ├── effector/{engage,suppress,destroy,disable}.py
│   ├── mover/{move_to,follow_route,halt,assume_posture}.py
│   ├── communicator/{send,relay,jam,report}.py
│   └── commander/{issue_order,request_support,delegate,escalate}.py
└── tests/                           35 passing
```

## Per-verb specifics worth flagging

- **`detect`** — per-modality EFFECT_FAMILY dispatch (`RF`→`ew_cone`, `RADAR`→`radar_fan`, `ACOUSTIC`/`SEISMIC`/`MASINT_MULTI`→`masint_cell`, `EO_IR`→none).
- **`destroy`** — stamps `payload.stake='high'` for the WS-405 adjudicator to flag `human_required=true`.
- **`disable`** — per-method dispatch (`KINETIC`→`indirect_fire_arc`, `EW`→`jamming_circle`, `CYBER`→none).
- **`relay`** — emits `uas_corridor` only when `is_airborne=True` AND `profile.communicator.advertise_corridor=True`. Both must hold.
- **`delegate`** — rejects with `ToolError` when `delegated_verbs ⊄ own action_verbs_available`.
- **`escalate`** — rejects with `ToolError` when `to_echelon` is not strictly higher than profile.commander.echelon (sideways/downward both blocked).

## Tests — 35 passing

```
$ pytest -v
tests/test_base.py ....                                                  [ 11%]
tests/test_commander.py ........                                         [ 34%]
tests/test_communicator.py ......                                        [ 51%]
tests/test_effector.py .......                                           [ 71%]
tests/test_mover.py ....                                                 [ 82%]
tests/test_sensor.py ......                                              [100%]
35 passed in 0.13s
```

- **20 verbs** covered with happy paths (some 2-3 variants for modality / method / conditional dispatch).
- **Reject paths**: validator out-of-range (`detect` RADAR over 50km, `engage` over 25km, `jam` power over 1500W), capability gate (us-bct lacks `jam` and `disable`), `delegate` not-in-authority, `escalate` sideways AND downward.
- **Sanity**: 20 unique verbs registered, all classes subclass `crewai.tools.BaseTool`.

Profiles loaded fresh from `kernel/capability-profiles/` at session start; tests use the **real** in-memory `NamespacedDag` and the **real** WS-202 `Validator`. No mocks of either upstream — drift surfaces on the next pytest run.

## Definition of done check

- [x] All criteria from #22's Definition of done satisfied: all 20 tools callable from a CrewAI agent in test harness; validator rejection paths exercised.
- [x] Documentation updated — `agents/tools/README.md` carries API contract, verb-by-verb inventory, and "what downstream crews must respect" guardrails lifted from WS-105 + better-late-than-never.
- [x] Tests added or updated — 35 passing.
- [x] Banner present on any new visual surface — N/A (Python library).

## Decisions worth flagging

1. **Each tool instance is bound to one `OfficerToolContext` at construction.** Standard CrewAI pattern; agent instantiates per-agent tool sets. WS-403/404/405 produce the context.
2. **`OfficerToolContext` extends Shane's `CrewContext`** with `agent_entity_id`, `capability_profile`, `kernel_dag`, `validator`. I did NOT modify Shane's `CrewContext` in `agents/runtime/`; that contract is his to expand when crews wire to agents.
3. **In-process validator import**, not HTTP. Library-shape from WS-202 made this trivial and faster than HTTP per call.
4. **`delegate` and `escalate` extras enforced inside `_build_event_payload`.** They're not validator concerns, they're verb-semantic concerns. The base flow lets verb classes raise `ToolError` from any hook.

## Downstream impact

- **Unblocks WS-403** (#23) — blue battalion crew stubs. Construct `OfficerToolContext` per agent, call `build_all_tools(ctx)` for the full toolbox or pluck `tools["engage"]` etc.
- **Unblocks WS-404** (#24) — red OpFor crew, same pattern.
- **Unblocks WS-405** (#25) — white cell adjudicator can read `payload.stake='high'` from `destroy` events as a high-stakes signal.
- **Cross-cuts WS-202 / WS-201 / WS-107** — any change to a profile range, template constraint, or template id is exercised by the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)