### PR TITLE
feat(renderer): EXCON consoles for blue/red operators (WS-504)

### DIFF
--- a/web/renderer/src/api/mock.ts
+++ b/web/renderer/src/api/mock.ts
@@ -1,0 +1,148 @@
+// Hackathon stubs. WS-504 builds the operator UI ahead of the agent runtime
+// (WS-402/403/404) and live-state endpoints. Each call here is the wire-shape
+// the renderer expects; the integration commit lives upstream of this file.
+
+import type { CellRole } from "../auth/jwt";
+
+export type EntityForce = "BLUE" | "RED" | "WHITE" | "NEUTRAL";
+
+export interface EntitySummary {
+  entity_id: string;
+  display_name: string;
+  type_subtype_ref: string;
+  force_affiliation: EntityForce;
+  position_lat_deg: number;
+  position_lon_deg: number;
+  position_alt_m: number;
+}
+
+export interface TurnSnapshot {
+  current_turn: number;
+  turn_state: "open" | "advancing";
+  last_advanced_at: string | null;
+}
+
+export interface OrderRequest {
+  tenant_id: string;
+  scenario_id: string;
+  cell_role: CellRole;
+  officer: string;
+  verb: string;
+  payload: Record<string, unknown>;
+}
+
+export interface OrderResponse {
+  accepted: boolean;
+  event_id?: string;
+  reason?: string;
+}
+
+const NASHVILLE = { lat: 36.18, lon: -86.78, alt: 200 };
+
+function shift(lat: number, lon: number, dLatM: number, dLonM: number) {
+  const M_PER_DLAT = 111_000;
+  const M_PER_DLON = 111_000 * Math.cos((lat * Math.PI) / 180);
+  return { lat: lat + dLatM / M_PER_DLAT, lon: lon + dLonM / M_PER_DLON };
+}
+
+function blueEntities(): EntitySummary[] {
+  return [
+    {
+      entity_id: "00000000-0000-4000-8000-000000000001",
+      display_name: "1-37 IN BN HQ",
+      type_subtype_ref: "notional.ground.bct.battalion",
+      force_affiliation: "BLUE",
+      ...nashAt(0, 0),
+    },
+    {
+      entity_id: "00000000-0000-4000-8000-000000000002",
+      display_name: "A/1-37 (CO A)",
+      type_subtype_ref: "notional.ground.bct.company",
+      force_affiliation: "BLUE",
+      ...nashAt(-1500, -800),
+    },
+    {
+      entity_id: "00000000-0000-4000-8000-000000000003",
+      display_name: "B/1-37 (CO B)",
+      type_subtype_ref: "notional.ground.bct.company",
+      force_affiliation: "BLUE",
+      ...nashAt(-2000, 600),
+    },
+    {
+      entity_id: "00000000-0000-4000-8000-000000000004",
+      display_name: "C/1-37 (CO C)",
+      type_subtype_ref: "notional.ground.bct.company",
+      force_affiliation: "BLUE",
+      ...nashAt(-1200, 1800),
+    },
+    {
+      entity_id: "00000000-0000-4000-8000-000000000005",
+      display_name: "FSC mortar section",
+      type_subtype_ref: "notional.indirect.medium",
+      force_affiliation: "BLUE",
+      ...nashAt(-2500, -1500),
+    },
+  ];
+}
+
+function redEntities(): EntitySummary[] {
+  return [
+    {
+      entity_id: "00000000-0000-4000-8000-000000000101",
+      display_name: "12 Mech Bn (FWD)",
+      type_subtype_ref: "notional.ground.opfor.bn",
+      force_affiliation: "RED",
+      ...nashAt(2200, 800),
+    },
+    {
+      entity_id: "00000000-0000-4000-8000-000000000102",
+      display_name: "Recon platoon",
+      type_subtype_ref: "notional.ground.opfor.recon",
+      force_affiliation: "RED",
+      ...nashAt(800, 1500),
+    },
+    {
+      entity_id: "00000000-0000-4000-8000-000000000103",
+      display_name: "EW battery (jam)",
+      type_subtype_ref: "notional.ew.peer.jammer",
+      force_affiliation: "RED",
+      ...nashAt(3000, -200),
+    },
+    {
+      entity_id: "00000000-0000-4000-8000-000000000104",
+      display_name: "UAS — Orlan-class",
+      type_subtype_ref: "notional.uas.peer.tactical",
+      force_affiliation: "RED",
+      ...nashAt(2800, 2400),
+    },
+  ];
+}
+
+function nashAt(dLatM: number, dLonM: number): { position_lat_deg: number; position_lon_deg: number; position_alt_m: number } {
+  const s = shift(NASHVILLE.lat, NASHVILLE.lon, dLatM, dLonM);
+  return { position_lat_deg: s.lat, position_lon_deg: s.lon, position_alt_m: NASHVILLE.alt };
+}
+
+export async function fetchFriendlyEntities(force: EntityForce): Promise<EntitySummary[]> {
+  // TODO WS-503/WS-104: replace with live query against the kernel/control-plane.
+  await new Promise((r) => setTimeout(r, 50));
+  return force === "BLUE" ? blueEntities() : redEntities();
+}
+
+export async function fetchTurnState(): Promise<TurnSnapshot> {
+  // TODO WS-302: GET /tenants/:id/scenarios/:sid/turn (endpoint not yet exposed
+  // in the public control-plane API; WS-302 ships /turns/advance only).
+  await new Promise((r) => setTimeout(r, 50));
+  return { current_turn: 3, turn_state: "open", last_advanced_at: "2026-04-25T22:14:00Z" };
+}
+
+export async function submitOrder(req: OrderRequest): Promise<OrderResponse> {
+  // TODO WS-402/WS-403/WS-404: route into the agent runtime via the tenant's
+  // turn-jobs queue. For v1 the renderer logs the order and pretends it was
+  // accepted so the demo loop ("operator drafts → effect renders → kernel
+  // commits") can be exercised against stubbed data.
+  // eslint-disable-next-line no-console
+  console.log("[WS-504 stub] order submitted", req);
+  await new Promise((r) => setTimeout(r, 100));
+  return { accepted: true, event_id: crypto.randomUUID() };
+}

--- a/web/renderer/src/auth/jwt.ts
+++ b/web/renderer/src/auth/jwt.ts
@@ -1,0 +1,80 @@
+// Lightweight client-side JWT decode. NO verification — the server is the
+// source of truth for auth; the renderer reads claims only to gate which
+// route to show / which cell-role console to render. JWT integrity is
+// re-verified on every API call by the control-plane and websocket service.
+
+import { useEffect, useState } from "react";
+
+export type CellRole = "white" | "blue" | "red" | "observer";
+
+export interface JwtClaims {
+  tenant_id: string;
+  cell_role: CellRole;
+  sub?: string;
+  exp?: number;
+  iat?: number;
+}
+
+const STORAGE_KEY = "almighty.jwt";
+
+function base64UrlDecode(input: string): string {
+  const padded = input.padEnd(input.length + ((4 - (input.length % 4)) % 4), "=");
+  const std = padded.replace(/-/g, "+").replace(/_/g, "/");
+  return atob(std);
+}
+
+export function decodeJwt(token: string): JwtClaims | null {
+  try {
+    const [, payloadB64] = token.split(".");
+    if (!payloadB64) return null;
+    const payload = JSON.parse(base64UrlDecode(payloadB64)) as Partial<JwtClaims>;
+    if (typeof payload.tenant_id !== "string") return null;
+    if (
+      payload.cell_role !== "white" &&
+      payload.cell_role !== "blue" &&
+      payload.cell_role !== "red" &&
+      payload.cell_role !== "observer"
+    ) {
+      return null;
+    }
+    return payload as JwtClaims;
+  } catch {
+    return null;
+  }
+}
+
+// Resolves a token from (in priority order): ?jwt= query param (also persists
+// to localStorage), then localStorage. The query-param flow is a hackathon
+// convenience for demos; real auth lands in a future ticket.
+function resolveToken(): string | null {
+  if (typeof window === "undefined") return null;
+  const params = new URLSearchParams(window.location.search);
+  const fromQuery = params.get("jwt");
+  if (fromQuery) {
+    window.localStorage.setItem(STORAGE_KEY, fromQuery);
+    return fromQuery;
+  }
+  return window.localStorage.getItem(STORAGE_KEY);
+}
+
+export function useJwtClaims(): JwtClaims | null {
+  const [claims, setClaims] = useState<JwtClaims | null>(() => {
+    const tok = resolveToken();
+    return tok ? decodeJwt(tok) : null;
+  });
+
+  useEffect(() => {
+    const onStorage = () => {
+      const tok = resolveToken();
+      setClaims(tok ? decodeJwt(tok) : null);
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  return claims;
+}
+
+export function getStoredToken(): string | null {
+  return typeof window === "undefined" ? null : window.localStorage.getItem(STORAGE_KEY);
+}

--- a/web/renderer/src/components/AccessDenied.tsx
+++ b/web/renderer/src/components/AccessDenied.tsx
@@ -1,0 +1,17 @@
+type AccessDeniedProps = {
+  required: string;
+  actual?: string;
+};
+
+export function AccessDenied({ required, actual }: AccessDeniedProps) {
+  return (
+    <div className="access-denied">
+      <h1>ACCESS DENIED</h1>
+      <p>This route requires cell role: <strong>{required}</strong></p>
+      <p>Your token: {actual ?? "<no token>"}</p>
+      <p className="access-denied__hint">
+        Append <code>?jwt=&lt;your-token&gt;</code> to the URL to set a token.
+      </p>
+    </div>
+  );
+}

--- a/web/renderer/src/components/EffectPreview.tsx
+++ b/web/renderer/src/components/EffectPreview.tsx
@@ -1,0 +1,81 @@
+import { Entity, EllipseGraphics, PolygonGraphics } from "resium";
+import { Cartesian3, Color, PolygonHierarchy } from "cesium";
+import type { VerbSpec } from "../verbs/registry";
+import type { FormValues } from "./OrderForm";
+
+const PREVIEW_COLOR = Color.fromBytes(255, 220, 100, 140);
+const PREVIEW_OUTLINE = Color.fromBytes(255, 220, 100, 220);
+
+type EffectPreviewProps = {
+  verb: VerbSpec | null;
+  values: FormValues;
+};
+
+/**
+ * Renders a 50%-opacity ghost shape on the map for the verb the operator is
+ * currently drafting. Uses simple Cesium primitives — not the WS-201 templates
+ * — because the renderer doesn't have the kernel's geometry-computation step.
+ * The shape kind matches what the eventual live packet will render.
+ */
+export function EffectPreview({ verb, values }: EffectPreviewProps) {
+  if (!verb || !verb.spatialArtifact) return null;
+
+  switch (verb.spatialArtifact) {
+    case "jamming_circle": {
+      const lon = num(values.center_lon_deg);
+      const lat = num(values.center_lat_deg);
+      const radius = num(values.radius_m);
+      if (lon === null || lat === null || !radius) return null;
+      return (
+        <Entity position={Cartesian3.fromDegrees(lon, lat, 0)}>
+          <EllipseGraphics
+            semiMajorAxis={radius}
+            semiMinorAxis={radius}
+            material={PREVIEW_COLOR}
+            outline
+            outlineColor={PREVIEW_OUTLINE}
+          />
+        </Entity>
+      );
+    }
+    case "indirect_fire_arc": {
+      const lon = num(values.target_lon_deg);
+      const lat = num(values.target_lat_deg);
+      if (lon === null || lat === null) return null;
+      // Shoot a small triangle marker at the impact point — placeholder for
+      // a true ballistic arc, which needs a firer position the form doesn't
+      // currently capture.
+      const halfDeg = 0.001;
+      return (
+        <Entity>
+          <PolygonGraphics
+            hierarchy={
+              new PolygonHierarchy(
+                Cartesian3.fromDegreesArray([
+                  lon - halfDeg, lat - halfDeg,
+                  lon + halfDeg, lat - halfDeg,
+                  lon, lat + halfDeg,
+                ]),
+              )
+            }
+            material={PREVIEW_COLOR}
+            outline
+            outlineColor={PREVIEW_OUTLINE}
+          />
+        </Entity>
+      );
+    }
+    case "keyhole_footprint": {
+      // No map coords on classify; preview is a no-op.
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+function num(v: string | number | boolean | null | undefined): number | null {
+  if (v === null || v === undefined || v === "") return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}

--- a/web/renderer/src/components/EntitySidebar.tsx
+++ b/web/renderer/src/components/EntitySidebar.tsx
@@ -1,0 +1,32 @@
+import type { EntitySummary } from "../api/mock";
+
+type EntitySidebarProps = {
+  entities: EntitySummary[];
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+  loading: boolean;
+};
+
+export function EntitySidebar({ entities, selectedId, onSelect, loading }: EntitySidebarProps) {
+  return (
+    <div className="entity-sidebar">
+      <h2>Entities under command</h2>
+      {loading && <p className="entity-sidebar__loading">loading…</p>}
+      <ul>
+        {entities.map((e) => (
+          <li
+            key={e.entity_id}
+            className={`entity-sidebar__row ${selectedId === e.entity_id ? "is-selected" : ""}`}
+            onClick={() => onSelect(selectedId === e.entity_id ? null : e.entity_id)}
+          >
+            <div className="entity-sidebar__name">{e.display_name}</div>
+            <div className="entity-sidebar__meta">{e.type_subtype_ref}</div>
+            <div className="entity-sidebar__coord">
+              {e.position_lat_deg.toFixed(4)}, {e.position_lon_deg.toFixed(4)}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/renderer/src/components/OrderForm.tsx
+++ b/web/renderer/src/components/OrderForm.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  type OfficerType,
+  VERBS,
+  type VerbField,
+  type VerbSpec,
+  getVerb,
+  verbsByOfficer,
+} from "../verbs/registry";
+
+const OFFICER_TYPES: readonly OfficerType[] = ["Sensor", "Effector", "Mover", "Communicator", "Commander"];
+
+export type FormValues = Record<string, string | number | boolean | null>;
+
+type OrderFormProps = {
+  /** Officers this console can issue orders for. EXCON blue/red can do all five; refine later if needed. */
+  allowedOfficers?: readonly OfficerType[];
+  /** Locked when the turn is advancing. */
+  locked: boolean;
+  onDraft: (verb: VerbSpec | null, values: FormValues) => void;
+  onSubmit: (verb: VerbSpec, values: FormValues) => void | Promise<void>;
+  submitting: boolean;
+};
+
+export function OrderForm({
+  allowedOfficers = OFFICER_TYPES,
+  locked,
+  onDraft,
+  onSubmit,
+  submitting,
+}: OrderFormProps) {
+  const [officer, setOfficer] = useState<OfficerType>(allowedOfficers[0]);
+  const verbsForOfficer = useMemo(() => verbsByOfficer(officer), [officer]);
+  const [verbName, setVerbName] = useState<string>(verbsForOfficer[0]?.verb ?? "");
+  const verb = getVerb(verbName);
+  const [values, setValues] = useState<FormValues>({});
+
+  // When the verb changes, reset values and seed defaults where useful.
+  useEffect(() => {
+    setValues({});
+  }, [verbName]);
+
+  // Surface the current draft upward (for ghost preview / debug).
+  useEffect(() => {
+    onDraft(verb ?? null, values);
+  }, [verb, values, onDraft]);
+
+  const setField = (name: string, value: string | number | boolean | null) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const validate = (): { ok: boolean; reason?: string } => {
+    if (!verb) return { ok: false, reason: "no verb selected" };
+    for (const f of verb.fields) {
+      if (!f.required) continue;
+      const v = values[f.name];
+      if (v === undefined || v === null || v === "") return { ok: false, reason: `${f.name} required` };
+    }
+    return { ok: true };
+  };
+  const validity = validate();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validity.ok || !verb || locked) return;
+    void onSubmit(verb, values);
+  };
+
+  return (
+    <form className="order-form" onSubmit={handleSubmit}>
+      <h2>Order entry</h2>
+
+      <label className="order-form__row">
+        <span>Officer</span>
+        <select
+          value={officer}
+          disabled={locked}
+          onChange={(e) => {
+            const next = e.target.value as OfficerType;
+            setOfficer(next);
+            const firstVerb = verbsByOfficer(next)[0]?.verb ?? "";
+            setVerbName(firstVerb);
+          }}
+        >
+          {allowedOfficers.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="order-form__row">
+        <span>Verb</span>
+        <select value={verbName} disabled={locked} onChange={(e) => setVerbName(e.target.value)}>
+          {verbsForOfficer.map((v) => (
+            <option key={v.verb} value={v.verb}>
+              {v.verb}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {verb?.fields.length === 0 && (
+        <p className="order-form__hint">
+          <em>{verb.verb}</em> has no parameters.
+        </p>
+      )}
+
+      {verb?.fields.map((f) => (
+        <FieldInput
+          key={f.name}
+          field={f}
+          value={values[f.name] ?? ""}
+          disabled={locked}
+          onChange={(v) => setField(f.name, v)}
+        />
+      ))}
+
+      {locked && <p className="order-form__locked">Turn is advancing — orders locked.</p>}
+
+      <button
+        type="submit"
+        className="order-form__submit"
+        disabled={locked || submitting || !validity.ok}
+      >
+        {submitting ? "submitting…" : "Issue order"}
+      </button>
+      {!validity.ok && validity.reason && (
+        <p className="order-form__validity">{validity.reason}</p>
+      )}
+    </form>
+  );
+}
+
+function FieldInput({
+  field,
+  value,
+  disabled,
+  onChange,
+}: {
+  field: VerbField;
+  value: string | number | boolean | null;
+  disabled: boolean;
+  onChange: (v: string | number | boolean | null) => void;
+}) {
+  const label = (
+    <span>
+      {field.name}
+      {field.units && <span className="order-form__units"> ({field.units})</span>}
+      {field.required && <span className="order-form__required"> *</span>}
+    </span>
+  );
+
+  if (field.type === "enum") {
+    return (
+      <label className="order-form__row">
+        {label}
+        <select
+          value={String(value ?? "")}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value || null)}
+        >
+          <option value="">—</option>
+          {field.enumValues?.map((v) => (
+            <option key={v} value={v}>
+              {v}
+            </option>
+          ))}
+        </select>
+      </label>
+    );
+  }
+
+  if (field.type === "bool") {
+    return (
+      <label className="order-form__row">
+        {label}
+        <input
+          type="checkbox"
+          checked={Boolean(value)}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+      </label>
+    );
+  }
+
+  if (field.type === "number") {
+    return (
+      <label className="order-form__row">
+        {label}
+        <input
+          type="number"
+          value={value === null || value === undefined ? "" : String(value)}
+          disabled={disabled}
+          min={field.min}
+          max={field.max}
+          step="any"
+          onChange={(e) => onChange(e.target.value === "" ? null : Number(e.target.value))}
+        />
+      </label>
+    );
+  }
+
+  // string / uuid / object → text input. object accepts JSON; renderer doesn't parse here.
+  return (
+    <label className="order-form__row">
+      {label}
+      <input
+        type="text"
+        value={String(value ?? "")}
+        disabled={disabled}
+        placeholder={field.description ?? ""}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </label>
+  );
+}
+
+export const ALL_VERBS_COUNT = VERBS.length;

--- a/web/renderer/src/components/TurnState.tsx
+++ b/web/renderer/src/components/TurnState.tsx
@@ -1,0 +1,17 @@
+import type { TurnSnapshot } from "../api/mock";
+
+type TurnStateProps = {
+  snapshot: TurnSnapshot | null;
+};
+
+export function TurnState({ snapshot }: TurnStateProps) {
+  if (!snapshot) return <div className="turn-state turn-state--loading">turn: …</div>;
+  const isAdvancing = snapshot.turn_state === "advancing";
+  return (
+    <div className={`turn-state ${isAdvancing ? "turn-state--advancing" : "turn-state--open"}`}>
+      <span className="turn-state__num">turn {snapshot.current_turn}</span>
+      <span className="turn-state__dot" />
+      <span className="turn-state__label">{snapshot.turn_state.toUpperCase()}</span>
+    </div>
+  );
+}

--- a/web/renderer/src/router.tsx
+++ b/web/renderer/src/router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, Navigate } from "react-router-dom";
 import { App } from "./App";
 import { ScenarioRoot } from "./routes/ScenarioRoot";
 import { Index } from "./routes/Index";
+import { ExconConsole } from "./routes/ExconConsole";
 
 export const router = createBrowserRouter([
   {
@@ -12,6 +13,14 @@ export const router = createBrowserRouter([
       {
         path: ":tenantId/scenarios/:scenarioId",
         element: <ScenarioRoot />,
+      },
+      {
+        path: ":tenantId/scenarios/:scenarioId/excon/blue",
+        element: <ExconConsole side="blue" />,
+      },
+      {
+        path: ":tenantId/scenarios/:scenarioId/excon/red",
+        element: <ExconConsole side="red" />,
       },
       { path: "*", element: <Navigate to="/" replace /> },
     ],

--- a/web/renderer/src/routes/ExconConsole.tsx
+++ b/web/renderer/src/routes/ExconConsole.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { Excon } from "../layouts/Excon";
+import { CesiumScene } from "../components/CesiumScene";
+import { EntitySidebar } from "../components/EntitySidebar";
+import { OrderForm, type FormValues } from "../components/OrderForm";
+import { EffectPreview } from "../components/EffectPreview";
+import { TurnState } from "../components/TurnState";
+import { AccessDenied } from "../components/AccessDenied";
+import { useJwtClaims, type CellRole } from "../auth/jwt";
+import {
+  type EntityForce,
+  type EntitySummary,
+  type TurnSnapshot,
+  fetchFriendlyEntities,
+  fetchTurnState,
+  submitOrder,
+} from "../api/mock";
+import type { VerbSpec } from "../verbs/registry";
+
+type ExconConsoleProps = {
+  side: "blue" | "red";
+};
+
+const FORCE_FOR_SIDE: Record<"blue" | "red", EntityForce> = {
+  blue: "BLUE",
+  red: "RED",
+};
+
+export function ExconConsole({ side }: ExconConsoleProps) {
+  const { tenantId, scenarioId } = useParams<{ tenantId: string; scenarioId: string }>();
+  const claims = useJwtClaims();
+  const requiredRole: CellRole = side;
+
+  const [entities, setEntities] = useState<EntitySummary[]>([]);
+  const [entitiesLoading, setEntitiesLoading] = useState(true);
+  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
+
+  const [turn, setTurn] = useState<TurnSnapshot | null>(null);
+
+  const [draftVerb, setDraftVerb] = useState<VerbSpec | null>(null);
+  const [draftValues, setDraftValues] = useState<FormValues>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [lastResult, setLastResult] = useState<string | null>(null);
+
+  // Load fixtures on mount. Re-fetch when the scenario changes.
+  useEffect(() => {
+    let cancelled = false;
+    setEntitiesLoading(true);
+    void (async () => {
+      const [e, t] = await Promise.all([
+        fetchFriendlyEntities(FORCE_FOR_SIDE[side]),
+        fetchTurnState(),
+      ]);
+      if (cancelled) return;
+      setEntities(e);
+      setTurn(t);
+      setEntitiesLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [side, scenarioId]);
+
+  const handleDraft = useCallback((verb: VerbSpec | null, values: FormValues) => {
+    setDraftVerb(verb);
+    setDraftValues(values);
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (verb: VerbSpec, values: FormValues) => {
+      if (!claims || !tenantId || !scenarioId) return;
+      setSubmitting(true);
+      try {
+        const res = await submitOrder({
+          tenant_id: tenantId,
+          scenario_id: scenarioId,
+          cell_role: claims.cell_role,
+          officer: verb.officer,
+          verb: verb.verb,
+          payload: values,
+        });
+        setLastResult(
+          res.accepted ? `accepted ${verb.verb} → ${res.event_id}` : `rejected: ${res.reason ?? "unknown"}`,
+        );
+      } catch (err) {
+        setLastResult(`error: ${err instanceof Error ? err.message : String(err)}`);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [claims, tenantId, scenarioId],
+  );
+
+  if (!claims || claims.cell_role !== requiredRole) {
+    return <AccessDenied required={requiredRole} actual={claims?.cell_role} />;
+  }
+
+  const locked = turn?.turn_state === "advancing";
+
+  return (
+    <Excon
+      sidebar={
+        <EntitySidebar
+          entities={entities}
+          selectedId={selectedEntityId}
+          onSelect={setSelectedEntityId}
+          loading={entitiesLoading}
+        />
+      }
+      map={
+        <>
+          <CesiumScene>
+            <EffectPreview verb={draftVerb} values={draftValues} />
+          </CesiumScene>
+          <div className="excon-overlay">
+            <TurnState snapshot={turn} />
+            <div className={`side-badge side-badge--${side}`}>{side.toUpperCase()} CELL</div>
+          </div>
+        </>
+      }
+      actions={
+        <div className="actions-pane">
+          <OrderForm
+            locked={locked}
+            onDraft={handleDraft}
+            onSubmit={handleSubmit}
+            submitting={submitting}
+          />
+          {lastResult && <p className="actions-pane__result">{lastResult}</p>}
+        </div>
+      }
+    />
+  );
+}

--- a/web/renderer/src/routes/Index.tsx
+++ b/web/renderer/src/routes/Index.tsx
@@ -4,12 +4,22 @@ export function Index() {
   return (
     <div className="index">
       <h1>Almighty</h1>
-      <p>Pick a scenario to enter:</p>
+      <p>Pick a surface:</p>
       <ul>
         <li>
-          <Link to="/demo/scenarios/demo">demo / demo</Link>
+          <Link to="/demo/scenarios/demo">demo / demo (scenario root)</Link>
+        </li>
+        <li>
+          <Link to="/demo/scenarios/demo/excon/blue">demo / demo — EXCON blue</Link>
+        </li>
+        <li>
+          <Link to="/demo/scenarios/demo/excon/red">demo / demo — EXCON red</Link>
         </li>
       </ul>
+      <p className="index__hint">
+        EXCON consoles require a JWT with the matching <code>cell_role</code>.
+        Append <code>?jwt=&lt;token&gt;</code> to the URL to set one.
+      </p>
     </div>
   );
 }

--- a/web/renderer/src/styles.css
+++ b/web/renderer/src/styles.css
@@ -73,7 +73,7 @@ body,
 
 .recenter-btn {
   position: absolute;
-  top: 12px;
+  top: 48px;
   right: 12px;
   z-index: 10;
   padding: 6px 12px;

--- a/web/renderer/src/styles.css
+++ b/web/renderer/src/styles.css
@@ -142,8 +142,269 @@ body,
 
 .index {
   padding: 24px;
+  max-width: 720px;
 }
 
 .index a {
   color: #8ec5ff;
+}
+
+.index__hint {
+  margin-top: 24px;
+  font-size: 12px;
+  color: #888;
+}
+
+/* ---------------- EXCON consoles ---------------- */
+
+.access-denied {
+  padding: 48px;
+  max-width: 640px;
+}
+
+.access-denied h1 {
+  color: #ff8080;
+  letter-spacing: 0.08em;
+  font-size: 18px;
+  margin: 0 0 16px;
+}
+
+.access-denied__hint {
+  margin-top: 32px;
+  font-size: 12px;
+  color: #888;
+}
+
+.entity-sidebar h2 {
+  margin: 0 0 12px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #999;
+}
+
+.entity-sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.entity-sidebar__row {
+  padding: 8px;
+  margin-bottom: 4px;
+  border-radius: 3px;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+
+.entity-sidebar__row:hover {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: #333;
+}
+
+.entity-sidebar__row.is-selected {
+  background: rgba(140, 200, 255, 0.12);
+  border-color: #4d6f8a;
+}
+
+.entity-sidebar__name {
+  font-size: 13px;
+  color: #eee;
+}
+
+.entity-sidebar__meta {
+  font-size: 11px;
+  color: #888;
+  margin-top: 2px;
+}
+
+.entity-sidebar__coord {
+  font-size: 10px;
+  color: #666;
+  font-family: ui-monospace, "SF Mono", monospace;
+  margin-top: 2px;
+}
+
+.entity-sidebar__loading {
+  font-size: 12px;
+  color: #888;
+}
+
+.actions-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.actions-pane__result {
+  font-size: 12px;
+  color: #8ec5ff;
+  background: rgba(140, 200, 255, 0.08);
+  padding: 8px;
+  border-radius: 3px;
+  font-family: ui-monospace, "SF Mono", monospace;
+  word-break: break-all;
+}
+
+.order-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.order-form h2 {
+  margin: 0 0 4px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #999;
+}
+
+.order-form__row {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #ccc;
+}
+
+.order-form__row select,
+.order-form__row input[type="text"],
+.order-form__row input[type="number"] {
+  background: #181818;
+  color: #eaeaea;
+  border: 1px solid #333;
+  border-radius: 3px;
+  padding: 4px 6px;
+  font-size: 12px;
+  font-family: inherit;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.order-form__row select:disabled,
+.order-form__row input:disabled {
+  opacity: 0.5;
+}
+
+.order-form__units {
+  color: #777;
+}
+
+.order-form__required {
+  color: #ff8080;
+}
+
+.order-form__hint {
+  font-size: 12px;
+  color: #888;
+}
+
+.order-form__locked {
+  font-size: 12px;
+  color: #ffb86c;
+  background: rgba(255, 184, 108, 0.08);
+  padding: 6px 8px;
+  border-radius: 3px;
+}
+
+.order-form__validity {
+  font-size: 11px;
+  color: #ff8080;
+  margin: 0;
+}
+
+.order-form__submit {
+  margin-top: 8px;
+  padding: 8px;
+  background: #2a4d6e;
+  color: #fff;
+  border: 1px solid #4d6f8a;
+  border-radius: 3px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.order-form__submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.order-form__submit:not(:disabled):hover {
+  background: #335f88;
+}
+
+.excon-overlay {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  right: 12px;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  pointer-events: none;
+}
+
+.excon-overlay > * {
+  pointer-events: auto;
+}
+
+.turn-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: rgba(20, 20, 20, 0.85);
+  border: 1px solid #555;
+  border-radius: 4px;
+  font-size: 12px;
+  color: #ccc;
+  font-family: ui-monospace, "SF Mono", monospace;
+}
+
+.turn-state__num {
+  color: #eee;
+}
+
+.turn-state__dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #4caf50;
+}
+
+.turn-state--advancing .turn-state__dot {
+  background: #ffb86c;
+  animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.3; }
+  100% { opacity: 1; }
+}
+
+.side-badge {
+  display: inline-block;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  font-family: ui-monospace, "SF Mono", monospace;
+}
+
+.side-badge--blue {
+  background: rgba(80, 140, 220, 0.2);
+  color: #8ec5ff;
+  border: 1px solid #4d6f8a;
+}
+
+.side-badge--red {
+  background: rgba(220, 80, 80, 0.2);
+  color: #ff9090;
+  border: 1px solid #8a4d4d;
 }

--- a/web/renderer/src/verbs/registry.ts
+++ b/web/renderer/src/verbs/registry.ts
@@ -1,0 +1,337 @@
+// Verb registry derived from docs/schema/officer-interfaces.md (WS-105).
+// Field names match the doc 1:1 — they're the keys that ship in the
+// PyRapide event payload.
+
+export type OfficerType = "Sensor" | "Effector" | "Mover" | "Communicator" | "Commander";
+
+export type VerbFieldType = "number" | "string" | "uuid" | "bool" | "enum" | "object";
+
+export interface VerbField {
+  name: string;
+  type: VerbFieldType;
+  units?: string;
+  required: boolean;
+  enumValues?: readonly string[];
+  min?: number;
+  max?: number;
+  description?: string;
+}
+
+export interface VerbSpec {
+  verb: string;
+  officer: OfficerType;
+  fields: readonly VerbField[];
+  /** Effect family from WS-108 — used for the on-map ghost preview. */
+  spatialArtifact?:
+    | "ew_cone"
+    | "uas_corridor"
+    | "radar_fan"
+    | "jamming_circle"
+    | "satellite_swath"
+    | "indirect_fire_arc"
+    | "ir_plume"
+    | "masint_cell"
+    | "keyhole_footprint";
+}
+
+export const VERBS: readonly VerbSpec[] = [
+  // ------- Sensor -------
+  {
+    verb: "detect",
+    officer: "Sensor",
+    fields: [
+      { name: "target_entity_id", type: "uuid", required: true },
+      {
+        name: "modality",
+        type: "enum",
+        required: true,
+        enumValues: ["EO_IR", "RF", "RADAR", "ACOUSTIC", "SEISMIC", "MASINT_MULTI"],
+      },
+      { name: "confidence", type: "number", required: true, min: 0, max: 1 },
+      { name: "range_m", type: "number", units: "m", required: true },
+    ],
+  },
+  {
+    verb: "track",
+    officer: "Sensor",
+    fields: [
+      { name: "target_entity_id", type: "uuid", required: true },
+      { name: "track_id", type: "uuid", required: false },
+      { name: "update_rate_hz", type: "number", units: "Hz", required: true },
+      { name: "lifetime_s", type: "number", units: "s", required: false },
+    ],
+  },
+  {
+    verb: "classify",
+    officer: "Sensor",
+    spatialArtifact: "keyhole_footprint",
+    fields: [
+      { name: "track_id", type: "uuid", required: true },
+      { name: "classification_label", type: "string", required: true },
+      { name: "confidence", type: "number", required: true, min: 0, max: 1 },
+      { name: "dwell_s", type: "number", units: "s", required: true },
+    ],
+  },
+  {
+    verb: "lose_track",
+    officer: "Sensor",
+    fields: [
+      { name: "track_id", type: "uuid", required: true },
+      {
+        name: "reason",
+        type: "enum",
+        required: true,
+        enumValues: ["OUT_OF_RANGE", "OCCLUDED", "JAMMED", "DECONFLICTED", "DESTROYED_TARGET", "OPERATOR_REQUEST"],
+      },
+    ],
+  },
+  // ------- Effector -------
+  {
+    verb: "engage",
+    officer: "Effector",
+    spatialArtifact: "indirect_fire_arc",
+    fields: [
+      { name: "target_lat_deg", type: "number", units: "deg", required: true, min: -90, max: 90 },
+      { name: "target_lon_deg", type: "number", units: "deg", required: true, min: -180, max: 180 },
+      { name: "target_alt_m", type: "number", units: "m", required: true },
+      { name: "weapon_system", type: "string", required: true },
+      { name: "volume_count", type: "number", required: true, min: 1 },
+      {
+        name: "intent",
+        type: "enum",
+        required: false,
+        enumValues: ["NEUTRALIZE", "SUPPRESS_AND_HOLD", "MARKER"],
+      },
+    ],
+  },
+  {
+    verb: "suppress",
+    officer: "Effector",
+    spatialArtifact: "indirect_fire_arc",
+    fields: [
+      { name: "target_lat_deg", type: "number", units: "deg", required: true, min: -90, max: 90 },
+      { name: "target_lon_deg", type: "number", units: "deg", required: true, min: -180, max: 180 },
+      { name: "weapon_system", type: "string", required: true },
+      { name: "duration_s", type: "number", units: "s", required: true },
+      { name: "rate_per_min", type: "number", units: "/min", required: true },
+    ],
+  },
+  {
+    verb: "destroy",
+    officer: "Effector",
+    spatialArtifact: "indirect_fire_arc",
+    fields: [
+      { name: "target_entity_id", type: "uuid", required: true },
+      { name: "weapon_system", type: "string", required: true },
+      { name: "volume_count", type: "number", required: true, min: 1 },
+      { name: "justification", type: "string", required: true },
+    ],
+  },
+  {
+    verb: "disable",
+    officer: "Effector",
+    fields: [
+      { name: "target_entity_id", type: "uuid", required: true },
+      {
+        name: "method",
+        type: "enum",
+        required: true,
+        enumValues: ["KINETIC", "EW", "CYBER"],
+      },
+      { name: "weapon_system", type: "string", required: true },
+      { name: "intensity", type: "number", required: false },
+    ],
+  },
+  // ------- Mover -------
+  {
+    verb: "move_to",
+    officer: "Mover",
+    fields: [
+      { name: "target_lat_deg", type: "number", units: "deg", required: true, min: -90, max: 90 },
+      { name: "target_lon_deg", type: "number", units: "deg", required: true, min: -180, max: 180 },
+      { name: "target_alt_m", type: "number", units: "m", required: true },
+      { name: "speed_mps", type: "number", units: "m/s", required: false },
+    ],
+  },
+  {
+    verb: "follow_route",
+    officer: "Mover",
+    fields: [
+      { name: "waypoints", type: "object", required: true, description: "JSON array of [lat, lon, alt] triples" },
+      { name: "speed_mps", type: "number", units: "m/s", required: false },
+      { name: "loop", type: "bool", required: false },
+    ],
+  },
+  { verb: "halt", officer: "Mover", fields: [] },
+  {
+    verb: "assume_posture",
+    officer: "Mover",
+    fields: [
+      {
+        name: "posture",
+        type: "enum",
+        required: true,
+        enumValues: ["HALTED", "MOUNTED", "DISMOUNTED", "DUG_IN", "ALERT", "REST"],
+      },
+      { name: "transition_s", type: "number", units: "s", required: false },
+    ],
+  },
+  // ------- Communicator -------
+  {
+    verb: "send",
+    officer: "Communicator",
+    fields: [
+      { name: "recipient_entity_id", type: "uuid", required: false },
+      { name: "recipient_role", type: "string", required: false },
+      {
+        name: "channel",
+        type: "enum",
+        required: true,
+        enumValues: ["VHF", "UHF", "HF", "SATCOM", "DATA"],
+      },
+      { name: "message_payload", type: "object", required: true, description: "JSON payload" },
+      {
+        name: "priority",
+        type: "enum",
+        required: false,
+        enumValues: ["ROUTINE", "PRIORITY", "IMMEDIATE", "FLASH"],
+      },
+    ],
+  },
+  {
+    verb: "relay",
+    officer: "Communicator",
+    fields: [
+      { name: "source_entity_id", type: "uuid", required: true },
+      { name: "recipient_entity_id", type: "uuid", required: true },
+      {
+        name: "channel",
+        type: "enum",
+        required: true,
+        enumValues: ["VHF", "UHF", "HF", "SATCOM", "DATA"],
+      },
+    ],
+  },
+  {
+    verb: "jam",
+    officer: "Communicator",
+    spatialArtifact: "jamming_circle",
+    fields: [
+      { name: "center_lat_deg", type: "number", units: "deg", required: true, min: -90, max: 90 },
+      { name: "center_lon_deg", type: "number", units: "deg", required: true, min: -180, max: 180 },
+      { name: "radius_m", type: "number", units: "m", required: true, min: 100, max: 8000 },
+      { name: "power_w", type: "number", units: "W", required: true, min: 10, max: 1500 },
+      {
+        name: "band",
+        type: "enum",
+        required: true,
+        enumValues: ["HF", "VHF", "UHF", "L", "S", "C", "X", "KU", "KA"],
+      },
+      { name: "duration_s", type: "number", units: "s", required: true },
+    ],
+  },
+  {
+    verb: "report",
+    officer: "Communicator",
+    fields: [
+      {
+        name: "report_type",
+        type: "enum",
+        required: true,
+        enumValues: ["SITREP", "SPOTREP", "LOGSTAT", "CASEVAC", "INTREP"],
+      },
+      { name: "report_payload", type: "object", required: true, description: "JSON payload" },
+      {
+        name: "to_echelon",
+        type: "enum",
+        required: true,
+        enumValues: ["COMPANY", "BATTALION", "BRIGADE", "DIVISION", "WHITE_CELL"],
+      },
+    ],
+  },
+  // ------- Commander -------
+  {
+    verb: "issue_order",
+    officer: "Commander",
+    fields: [
+      { name: "to_entity_id", type: "uuid", required: false },
+      {
+        name: "to_echelon",
+        type: "enum",
+        required: false,
+        enumValues: ["COMPANY", "BATTALION", "BRIGADE", "DIVISION", "WHITE_CELL"],
+      },
+      {
+        name: "order_type",
+        type: "enum",
+        required: true,
+        enumValues: ["MOVE", "ATTACK", "DEFEND", "RECON", "SUPPORT", "WITHDRAW"],
+      },
+      { name: "order_payload", type: "object", required: true, description: "JSON payload" },
+      {
+        name: "priority",
+        type: "enum",
+        required: false,
+        enumValues: ["LOW", "MEDIUM", "HIGH"],
+      },
+    ],
+  },
+  {
+    verb: "request_support",
+    officer: "Commander",
+    fields: [
+      {
+        name: "support_type",
+        type: "enum",
+        required: true,
+        enumValues: ["FIRES", "ISR", "MEDEVAC", "LOGISTICS", "EW", "AIR"],
+      },
+      { name: "target_lat_deg", type: "number", units: "deg", required: false, min: -90, max: 90 },
+      { name: "target_lon_deg", type: "number", units: "deg", required: false, min: -180, max: 180 },
+      { name: "justification", type: "string", required: true },
+      {
+        name: "priority",
+        type: "enum",
+        required: true,
+        enumValues: ["LOW", "MEDIUM", "HIGH", "IMMEDIATE"],
+      },
+    ],
+  },
+  {
+    verb: "delegate",
+    officer: "Commander",
+    fields: [
+      { name: "to_entity_id", type: "uuid", required: true },
+      { name: "delegated_verbs", type: "object", required: true, description: "JSON array of verb names" },
+      { name: "ttl_turns", type: "number", units: "turns", required: true, min: 1 },
+    ],
+  },
+  {
+    verb: "escalate",
+    officer: "Commander",
+    fields: [
+      { name: "reason", type: "string", required: true },
+      {
+        name: "severity",
+        type: "enum",
+        required: true,
+        enumValues: ["ROUTINE", "PRIORITY", "FLASH"],
+      },
+      {
+        name: "to_echelon",
+        type: "enum",
+        required: true,
+        enumValues: ["COMPANY", "BATTALION", "BRIGADE", "DIVISION", "WHITE_CELL"],
+      },
+      { name: "references", type: "object", required: false, description: "JSON object" },
+    ],
+  },
+] as const;
+
+export function verbsByOfficer(officer: OfficerType): readonly VerbSpec[] {
+  return VERBS.filter((v) => v.officer === officer);
+}
+
+export function getVerb(name: string): VerbSpec | undefined {
+  return VERBS.find((v) => v.verb === name);
+}


### PR DESCRIPTION
## Summary
- New routes \`/:tenantId/scenarios/:scenarioId/excon/{blue,red}\` mounting the WS-501 Excon layout with a cell-role-gated operator console.
- **Sidebar**: list of friendly entities under command (5 BLUE / 4 RED, mocked fixture data; \`TODO WS-503/WS-104\` for live).
- **Map**: WS-501 Cesium scene with an \`EffectPreview\` overlay child that renders a 50%-opacity ghost shape live as the operator drafts a spatial-effect verb.
- **Order entry**: dynamic form driven by \`src/verbs/registry.ts\` — all 20 verbs from WS-105 with type-aware inputs (number / string / enum / bool / object), required-field validation gates submit, no-arg verbs (e.g., \`halt\`) submit as-is.
- **Turn state**: badge top-left ('open' / 'advancing'). Form locks when state == 'advancing'.
- **Side badge**: \`BLUE CELL\` / \`RED CELL\` indicator top-right.
- **Auth**: \`useJwtClaims()\` reads the JWT (from \`?jwt=\` query param, persisted to localStorage). Wrong cell_role → \`ACCESS DENIED\` page. Server is the source of truth for auth — renderer decode is naive (no signature verification), used only for route gating.

## Hackathon stubs
All in \`src/api/mock.ts\` with explicit \`TODO\` markers:
- \`fetchFriendlyEntities\` (\`TODO WS-503/WS-104\`)
- \`fetchTurnState\` (\`TODO WS-302\`: endpoint not yet exposed; control-plane currently ships \`/turns/advance\` only)
- \`submitOrder\` (\`TODO WS-402/403/404\`: route into the agent runtime via the tenant turn-jobs queue). Logs the order and returns \`accepted=true\` so the demo loop is exercisable now.

When the agent runtime lands, wiring is one commit per stub — the renderer-side wire shape is fixed.

Closes #29.

## Test plan
- [ ] \`cd web/renderer && pnpm dev\`
- [ ] Generate dev JWTs (any \`{alg:none}\` JWT with \`tenant_id\` + \`cell_role\` works for client-side decode)
- [ ] Visit \`/demo/scenarios/demo/excon/blue?jwt=<BLUE>&token=<CESIUM>\` → 5 entity sidebar, BLUE CELL badge, turn 3 OPEN, dynamic form
- [ ] Pick **Communicator → jam**, type lat/lon/radius → yellow ghost circle appears live; submit → \`accepted jam → <uuid>\` and console log
- [ ] Pick **Mover → halt** (no fields) → submits cleanly
- [ ] Visit blue route with RED token → ACCESS DENIED
- [ ] Visit red route with RED token → 4 red entities, RED CELL badge
- [ ] Pre-existing routes (\`/\`, \`/demo/scenarios/demo\`, \`?dev=1\` toggle) unchanged