### PR TITLE
WS-403 — Blue battalion crew stubs

### DIFF
--- a/agents/blue/README.md
+++ b/agents/blue/README.md
@@ -1,0 +1,197 @@
+# `almighty-blue-crew` — WS-403
+
+> **Classification:** UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY
+
+CrewAI agents for the blue battalion in the Nashville Cumberland River
+crossing scenario. Six roles, all bound to the
+[`us-bct.json`](../../kernel/capability-profiles/us-bct.json) capability
+profile (WS-107):
+
+| Role | Officer types | Verbs in scope |
+|---|---|---|
+| **S2 Intelligence** | SENSOR | `detect`, `track`, `classify`, `lose_track` |
+| **S3 Operations** | COMMANDER | `issue_order`, `request_support`, `delegate`, `escalate` |
+| **S6 Signal** | COMMUNICATOR | `send`, `relay`, `report` (no `jam` — us-bct doesn't authorize it) |
+| **Co A** | MOVER + EFFECTOR + COMMUNICATOR | left flank — `move_to`, `engage`, `send`, … |
+| **Co B** | MOVER + EFFECTOR + COMMUNICATOR | center / main effort over the crossing |
+| **Co C** | MOVER + EFFECTOR + COMMUNICATOR | right flank, frequent reposition |
+
+Each agent's goal and backstory key off public unclassified doctrine
+(FM 3-21.20, ATP 3-90.5, ATP 2-01.3) and the Cumberland River
+geography. No specific real-world weapon system is named.
+
+## What the v1 crew is — and what it isn't
+
+The v1 crew is **deterministic**. Each role is a real `crewai.Agent`
+with the proper `role` / `goal` / `backstory` / `tools` so the agent
+SHAPE matches what an LLM-driven loop will need later. But the
+between-turn execution is a scripted Python sequence that calls each
+tool's `_run()` directly in the WS-105 order.
+
+This satisfies the DoD ("crew runs one full between-turn cycle
+producing valid PyRapide events") without burning API keys or
+introducing nondeterminism into the test suite. v2 swaps in
+`Crew.kickoff()` once LLM access and cost / latency budgets are sorted;
+the spec files (`s2.py`, `s3.py`, etc.) are already shaped for it.
+
+## Between-turn sequence
+
+```
+S2.detect          (RADAR contact on red UAS-equivalent)
+    ↓
+S2.classify        (refine into a typed classification)
+    ↓
+S3.issue_order     (MOVE order to Co A)
+    ↓
+S3.request_support (ISR request to higher echelon)
+    ↓
+Co A.assume_posture(DUG_IN)
+    ↓
+Co A.send          (SITREP to S3 over VHF)
+    ↓
+Co B.halt          (commit to defensive line)
+    ↓
+Co B.suppress      (indirect-fire suppression on east-bank NAI)
+    ↓
+Co C.move_to       (slight reposition north)
+    ↓
+S6.send            (HF comms-status to BRIGADE_S6)
+    ↓
+S6.report          (SITREP to BRIGADE)
+```
+
+11 tool calls per cycle → 11 KernelEvents committed through
+`NamespacedDag.commit()`. Officer-type distribution: 2 SENSOR, 2
+COMMANDER, 3 MOVER, 1 EFFECTOR, 3 COMMUNICATOR.
+
+## API contract
+
+```python
+from almighty_agent_runtime.crews import CrewContext
+from almighty_blue_crew import run_blue_crew
+
+ctx = CrewContext(
+    tenant_id="11111111-1111-4111-8111-111111111111",
+    scenario_id="22222222-2222-4222-8222-222222222222",
+    turn=1,
+)
+result = run_blue_crew(ctx)
+# CrewResult(crew='blue', duration_ms=…, notes='v1 deterministic blue crew — 11 events committed', metadata={...})
+```
+
+`metadata.steps` is a list of `{step, event_id, verb, officer_type,
+validator}` rows in execution order. `metadata.validator_rejections` is
+guaranteed `0` for the happy path; any reject would have raised
+`ToolError` and aborted the cycle.
+
+## Integration with WS-401 harness
+
+The v1 crew matches Shane's `CrewRunner = Callable[[CrewContext],
+CrewResult]` signature and exports `BLUE_RUNNER`. The WS-401 harness's
+`BLUE_CREWS["default"]` is currently the no-op stub; a follow-up ticket
+will swap it for `BLUE_RUNNER`:
+
+```python
+# In agents/runtime/src/almighty_agent_runtime/crews.py:
+from almighty_blue_crew import BLUE_RUNNER
+BLUE_CREWS["default"] = BLUE_RUNNER
+```
+
+That swap is intentionally NOT in this PR — it should land when WS-403
+/ WS-404 / WS-405 all exist so the harness has all three crews live
+together.
+
+## Why the crew is self-contained (instantiates its own DAG + Validator)
+
+Shane's `CrewContext` carries only `(tenant_id, scenario_id, turn)`.
+The crew needs more (capability profile, kernel DAG, validator) and
+those pieces are not yet plumbed through the harness. Rather than
+extend Shane's contract from this PR, the v1 crew **instantiates a
+fresh `NamespacedDag` and `Validator` per call** and attributes events
+to synthetic per-role `agent_entity_id`s.
+
+This means events committed in a run are LOST when the function
+returns. That's acceptable for the v1 stub DoD ("produces valid
+PyRapide events" — production, not persistence is the bar). v2 wires
+the harness-supplied DAG handle through a richer context; entity
+bindings will land alongside.
+
+## Run
+
+```bash
+# From this directory (agents/blue/):
+python3.13 -m venv .venv
+source .venv/bin/activate
+
+# Install editable deps in topological order:
+pip install -e ../../kernel
+pip install -e ../../services/czml-validator
+pip install -e ../runtime
+pip install -e ../tools
+pip install -e ".[dev]"
+
+# Run the test suite:
+pytest -v
+```
+
+## Tests — 5 passing
+
+- **`test_crew_runs_one_full_cycle`** — the DoD test. One call →
+  11 events committed, zero validator rejections.
+- **`test_every_step_has_an_event_id`** — every step result carries a
+  unique `event_id`.
+- **`test_officer_type_distribution`** — the 11 events split across
+  officer types as the script predicts (2 SENSOR / 2 COMMANDER / 3
+  MOVER / 1 EFFECTOR / 3 COMMUNICATOR).
+- **`test_every_step_validator_field_set`** — every step declares
+  `accepted` (CZML-emitting) or `skipped` (non-spatial); at least one
+  `accepted` so the validator path was exercised end-to-end.
+- **`test_runner_export_is_callable`** — `BLUE_RUNNER` matches Shane's
+  `CrewRunner` signature for the eventual WS-401 swap.
+
+## Layout
+
+```
+agents/blue/
+├── pyproject.toml
+├── README.md                                       ← this file
+├── src/almighty_blue_crew/
+│   ├── __init__.py                                 ← exports run_blue_crew, BLUE_RUNNER
+│   ├── doctrine.py                                 ← Cumberland River anchors, doctrine refs
+│   ├── profile.py                                  ← us-bct.json loader (cached)
+│   ├── s2.py, s3.py, s6.py                         ← role spec modules (ROLE/GOAL/BACKSTORY/ALLOWED_VERBS)
+│   ├── co_a.py, co_b.py, co_c.py                   ← company commander spec modules
+│   └── crew.py                                     ← orchestration + deterministic script
+└── tests/
+    ├── conftest.py
+    └── test_crew.py
+```
+
+## Notes / open questions
+
+- **No `disable` verb in us-bct.** us-bct.json does not include `disable`
+  in `action_verbs_available`, so the company commanders' `ALLOWED_VERBS`
+  declare `engage`/`suppress`/`destroy` only. If a future profile
+  variant adds `disable`, update the company spec files.
+- **No `jam` verb in us-bct.** S6's `ALLOWED_VERBS` omits `jam` for the
+  same reason. The role's backstory explains the defensive posture;
+  the `Communicator.bands` block on us-bct still declares max-power
+  ranges per band, but the verb gate prevents emission.
+- **`destroy` is high-stakes.** Companies have `destroy` in their
+  allowed set, but the v1 script does NOT call `destroy` — that path
+  is reserved for the WS-405 adjudicator's
+  `human_required = true` flow once the white cell is live.
+- **Doctrinal sources.** Backstories cite FM 3-21.20, ATP 3-90.5, ATP
+  2-01.3 explicitly. If WS-403 grows specific tool callouts (e.g.,
+  named weapon families), keep them generic per the
+  better-late-than-never doc's project-conventions rules.
+
+## See also
+
+- [`docs/schema/officer-interfaces.md`](../../docs/schema/officer-interfaces.md) — verb signatures (WS-105).
+- [`docs/schema/capability-profiles.md`](../../docs/schema/capability-profiles.md) — profile schema (WS-106).
+- [`kernel/capability-profiles/us-bct.json`](../../kernel/capability-profiles/us-bct.json) — the bound profile (WS-107).
+- [`agents/tools/`](../tools/) — the 20 officer tool wrappers (WS-402).
+- [`agents/runtime/`](../runtime/) — the harness this crew plugs into (WS-401).
+- WS-404 (#24) — red OpFor crew, sibling.
+- WS-405 (#25) — white cell adjudicator, sibling.

--- a/agents/blue/pyproject.toml
+++ b/agents/blue/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "almighty-blue-crew"
+version = "0.1.0"
+description = "Almighty blue battalion crew stubs (WS-403)"
+requires-python = ">=3.11"
+authors = [{ name = "Almighty Team" }]
+dependencies = [
+    "crewai>=0.95",
+    "pydantic>=2.6",
+    "almighty-officer-tools",
+    "almighty-agent-runtime",
+    "almighty-czml-validator",
+    "almighty-kernel",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["almighty_blue_crew*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/agents/blue/src/almighty_blue_crew/__init__.py
+++ b/agents/blue/src/almighty_blue_crew/__init__.py
@@ -1,0 +1,13 @@
+"""Almighty blue battalion crew stubs (WS-403).
+
+A US BCT defending the Cumberland River west bank. Six CrewAI agents:
+
+  S2 (intelligence)  → S3 (operations)  → companies A/B/C  → S6 (signal)
+
+Sequenced as a between-turn process. The v1 crew is deterministic — see
+README.md for the rationale and the v2 LLM-driven path.
+"""
+
+from .crew import BLUE_RUNNER, run_blue_crew
+
+__all__ = ["run_blue_crew", "BLUE_RUNNER"]

--- a/agents/blue/src/almighty_blue_crew/co_a.py
+++ b/agents/blue/src/almighty_blue_crew/co_a.py
@@ -1,0 +1,51 @@
+"""Company A commander — leftmost (south-most) west-bank position.
+
+Company commanders execute S3 orders at the company level. They have
+Mover, Effector, and Communicator tool access (no Sensor, no broader
+Commander verbs other than what S3 delegates).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .doctrine import (
+    COMPANY_A_POSITION,
+    PUBLIC_DOCTRINE_REFERENCES,
+    THEATER_BACKGROUND,
+)
+
+ROLE: Final[str] = "Company A Commander"
+
+GOAL: Final[str] = (
+    "Hold the southern (left) flank of the battalion's defensive line. "
+    "Move and posture the company per S3 orders, engage red elements "
+    "that enter the company's assigned engagement area, and report "
+    "status to S6 / S3. Defer high-stakes engagements (`destroy`) to "
+    "white-cell adjudication."
+)
+
+BACKSTORY: Final[str] = (
+    f"{THEATER_BACKGROUND}\n\n"
+    f"You are the commander of Company A, postured at "
+    f"({COMPANY_A_POSITION.lat_deg:.4f}°N, {COMPANY_A_POSITION.lon_deg:.4f}°W). "
+    "Your tools are Mover (move_to / follow_route / halt / "
+    "assume_posture), Effector (engage / suppress / destroy / disable), "
+    "and Communicator (send / relay / report). You do not collect "
+    "intelligence directly — that is the S2's role; you consume the "
+    "tracks the S2 produces and act within the engagement criteria S3 "
+    "issues. `destroy` is always high-stakes; the white cell will hold "
+    "those events for human review.\n\n"
+    f"{PUBLIC_DOCTRINE_REFERENCES}"
+)
+
+ALLOWED_VERBS: Final[frozenset[str]] = frozenset(
+    {
+        # Mover
+        "move_to", "follow_route", "halt", "assume_posture",
+        # Effector — note us-bct does not allow 'disable'.
+        "engage", "suppress", "destroy",
+        # Communicator
+        "send", "relay", "report",
+    }
+)

--- a/agents/blue/src/almighty_blue_crew/co_b.py
+++ b/agents/blue/src/almighty_blue_crew/co_b.py
@@ -1,0 +1,40 @@
+"""Company B commander — center west-bank position covering the crossing."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .doctrine import (
+    COMPANY_B_POSITION,
+    PUBLIC_DOCTRINE_REFERENCES,
+    THEATER_BACKGROUND,
+)
+
+ROLE: Final[str] = "Company B Commander"
+
+GOAL: Final[str] = (
+    "Hold the center of the battalion's defensive line, directly "
+    "covering the most likely crossing point. Be prepared to fix red "
+    "elements in the engagement area while flank companies maneuver. "
+    "Maintain comms with S6 and report status to S3."
+)
+
+BACKSTORY: Final[str] = (
+    f"{THEATER_BACKGROUND}\n\n"
+    f"You are the commander of Company B, postured at "
+    f"({COMPANY_B_POSITION.lat_deg:.4f}°N, {COMPANY_B_POSITION.lon_deg:.4f}°W). "
+    "Your sector covers the most likely red crossing point and you are "
+    "the battalion's main effort if a forced crossing develops. Your "
+    "tools are Mover, Effector, and Communicator. You do not call "
+    "Sensor verbs; the S2 fuses the picture and pushes priority "
+    "intelligence to you through S3.\n\n"
+    f"{PUBLIC_DOCTRINE_REFERENCES}"
+)
+
+ALLOWED_VERBS: Final[frozenset[str]] = frozenset(
+    {
+        "move_to", "follow_route", "halt", "assume_posture",
+        "engage", "suppress", "destroy",
+        "send", "relay", "report",
+    }
+)

--- a/agents/blue/src/almighty_blue_crew/co_c.py
+++ b/agents/blue/src/almighty_blue_crew/co_c.py
@@ -1,0 +1,41 @@
+"""Company C commander — northern (right) flank west-bank position."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .doctrine import (
+    COMPANY_C_POSITION,
+    PUBLIC_DOCTRINE_REFERENCES,
+    THEATER_BACKGROUND,
+)
+
+ROLE: Final[str] = "Company C Commander"
+
+GOAL: Final[str] = (
+    "Hold the northern (right) flank of the battalion's defensive "
+    "line. Watch for upstream red attempts to cross outside the "
+    "battalion's primary engagement area. Be prepared to reposition "
+    "to support Company B if the main effort develops. Report status "
+    "to S3 and coordinate comms posture with S6."
+)
+
+BACKSTORY: Final[str] = (
+    f"{THEATER_BACKGROUND}\n\n"
+    f"You are the commander of Company C, postured at "
+    f"({COMPANY_C_POSITION.lat_deg:.4f}°N, {COMPANY_C_POSITION.lon_deg:.4f}°W). "
+    "Your sector covers the upstream / north end of the battalion's "
+    "AOR. Your tools are Mover, Effector, and Communicator. You will "
+    "frequently be the company that maneuvers to a new posture rather "
+    "than holding a defensive line — your `assume_posture` and "
+    "`move_to` activity is the battalion's flexibility.\n\n"
+    f"{PUBLIC_DOCTRINE_REFERENCES}"
+)
+
+ALLOWED_VERBS: Final[frozenset[str]] = frozenset(
+    {
+        "move_to", "follow_route", "halt", "assume_posture",
+        "engage", "suppress", "destroy",
+        "send", "relay", "report",
+    }
+)

--- a/agents/blue/src/almighty_blue_crew/crew.py
+++ b/agents/blue/src/almighty_blue_crew/crew.py
@@ -1,0 +1,323 @@
+"""Blue battalion crew orchestration (WS-403).
+
+The v1 crew is **deterministic**. Each role is defined as a real
+:class:`crewai.Agent` with the proper role / goal / backstory / tools so
+the agent SHAPE matches what WS-403 will need when LLM-driven
+execution lands. But the actual between-turn cycle is a scripted
+sequence that calls each tool's ``_run`` directly, in the WS-105 order:
+
+    S2  → S3  → companies (A → B → C)  → S6
+
+This satisfies the DoD ("crew runs one full between-turn cycle producing
+valid PyRapide events") without burning API keys or introducing
+nondeterminism into the test suite. v2 swaps in ``Crew.kickoff()`` once
+LLM access and cost / latency budgets are sorted; the spec files (s2.py,
+s3.py, etc.) are already shaped for it.
+
+Each agent gets its own ``OfficerToolContext`` with its own
+``agent_entity_id`` so events committed to the namespaced DAG are
+correctly attributed per-role.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Final
+from uuid import UUID, uuid4
+
+from almighty_agent_runtime.crews import CrewContext, CrewResult
+from almighty_czml_validator import Validator
+from almighty_kernel.dag import NamespacedDag
+from almighty_officer_tools import OfficerToolContext, build_all_tools
+from almighty_officer_tools.base import OfficerToolBase
+from crewai import Agent
+
+from . import co_a, co_b, co_c, s2, s3, s6
+from .doctrine import (
+    COMPANY_A_POSITION,
+    COMPANY_B_POSITION,
+    COMPANY_C_POSITION,
+    EAST_BANK_NAMED_AREA_OF_INTEREST,
+    WEST_BANK_BN_HQ,
+    WEST_BANK_OBSERVATION_POST,
+)
+from .profile import load_us_bct_profile
+
+# Roles in execution order. Mirrors S2 → S3 → companies → S6.
+_ROLE_MODULES = [s2, s3, co_a, co_b, co_c, s6]
+
+
+@dataclass
+class _RoleBinding:
+    """Per-role bundle: the CrewAI Agent shape + the bound tool subset
+    + the OfficerToolContext so the deterministic script can read
+    agent_entity_id when assembling event payloads."""
+
+    name: str
+    agent: Agent
+    ctx: OfficerToolContext
+    tools: dict[str, OfficerToolBase]
+
+
+def _build_role(
+    spec_module: Any,
+    *,
+    crew_ctx: CrewContext,
+    capability_profile: dict[str, Any],
+    kernel_dag: NamespacedDag,
+    validator: Validator,
+) -> _RoleBinding:
+    """Construct one role's Agent + tool context from a spec module."""
+    agent_entity_id = uuid4()
+    ctx = OfficerToolContext(
+        tenant_id=UUID(crew_ctx.tenant_id),
+        scenario_id=UUID(crew_ctx.scenario_id),
+        turn=crew_ctx.turn,
+        agent_entity_id=agent_entity_id,
+        capability_profile=capability_profile,
+        kernel_dag=kernel_dag,
+        validator=validator,
+    )
+    all_tools = build_all_tools(ctx)
+    scoped_tools = {
+        verb: tool for verb, tool in all_tools.items() if verb in spec_module.ALLOWED_VERBS
+    }
+    agent = Agent(
+        role=spec_module.ROLE,
+        goal=spec_module.GOAL,
+        backstory=spec_module.BACKSTORY,
+        tools=list(scoped_tools.values()),
+        allow_delegation=False,
+        verbose=False,
+        # No LLM is configured: the v1 crew is deterministic and never
+        # invokes Crew.kickoff(). Agent construction works without an
+        # LLM as long as kickoff() is never called.
+        llm=None,
+    )
+    return _RoleBinding(
+        name=spec_module.__name__.rsplit(".", 1)[-1],
+        agent=agent,
+        ctx=ctx,
+        tools=scoped_tools,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic between-turn script
+# ---------------------------------------------------------------------------
+
+# A single "step" calls one tool with a payload; the script is a list of
+# these. Steps are executed sequentially in the order declared. Any tool
+# raising ToolError aborts the cycle (failing the test).
+
+_StepFn = Callable[[dict[str, _RoleBinding]], dict[str, Any]]
+
+
+def _step_s2_detect(roles: dict[str, _RoleBinding]) -> dict[str, Any]:
+    s2_role = roles["s2"]
+    return s2_role.tools["detect"]._run(
+        target_entity_id=uuid4(),  # synthetic red track id
+        modality="RADAR",
+        confidence=0.85,
+        range_m=12_000.0,
+    )
+
+
+def _step_s2_classify(roles: dict[str, _RoleBinding]) -> dict[str, Any]:
+    s2_role = roles["s2"]
+    return s2_role.tools["classify"]._run(
+        track_id=uuid4(),
+        classification_label="notional.air.uas.medium",
+        confidence=0.78,
+        dwell_s=15.0,
+    )
+
+
+def _step_s3_issue_order_to_a(roles: dict[str, _RoleBinding]) -> dict[str, Any]:
+    s3_role = roles["s3"]
+    co_a_role = roles["co_a"]
+    return s3_role.tools["issue_order"]._run(
+        order_type="MOVE",
+        order_payload={
+            "waypoints": [
+                {
+                    "lat_deg": COMPANY_A_POSITION.lat_deg,
+                    "lon_deg": COMPANY_A_POSITION.lon_deg,
+                    "alt_m": COMPANY_A_POSITION.alt_m,
+                }
+            ],
+        },
+        to_entity_id=co_a_role.ctx.agent_entity_id,
+        priority="MEDIUM",
+    )
+
+
+def _step_s3_request_isr(roles: dict[str, _RoleBinding]) -> dict[str, Any]:
+    s3_role = roles["s3"]
+    return s3_role.tools["request_support"]._run(
+        support_type="ISR",
+        justification="confirm red UAS overflight pattern",
+        priority="HIGH",
+    )
+
+
+def _step_co_a_assume_posture(roles: dict[str, _RoleBinding]) -> dict[str, Any]:
+    return roles["co_a"].tools["assume_posture"]._run(posture="DUG_IN")
+
+
+def _step_co_a_send_sitrep(roles: dict[str, _RoleBinding]) -> dict[str, Any]:
+    bn_hq = roles["s3"].ctx.agent_entity_id  # CO A reports to S3
+    return roles["co_a"].tools["send"]._run(
+        channel="VHF",
+        message_payload={
+            "type": "SITREP",
+            "line1": "in position; no contact",
+        },
+        recipient_entity_id=bn_hq,
+        priority="ROUTINE",
+    )
+
+
+def _step_co_b_halt(roles: dict[str, _RoleBinding]) -> dict[str, Any]:
+    return roles["co_b"].tools["halt"]._run()
+
+
+def _step_co_b_suppress(roles: dict[str, _RoleBinding]) -> dict[str, Any]:
+    return roles["co_b"].tools["suppress"]._run(
+        weapon_system="notional.indirect.medium",
+        duration_s=60.0,
+        rate_per_min=4.0,
+        target_lat_deg=EAST_BANK_NAMED_AREA_OF_INTEREST.lat_deg,
+        target_lon_deg=EAST_BANK_NAMED_AREA_OF_INTEREST.lon_deg,
+        target_alt_m=EAST_BANK_NAMED_AREA_OF_INTEREST.alt_m,
+        range_m=8_000.0,
+        time_of_flight_s=18.0,
+    )
+
+
+def _step_co_c_move(roles: dict[str, _RoleBinding]) -> dict[str, Any]:
+    return roles["co_c"].tools["move_to"]._run(
+        target_lat_deg=COMPANY_C_POSITION.lat_deg + 0.005,  # slight repositioning N
+        target_lon_deg=COMPANY_C_POSITION.lon_deg,
+        target_alt_m=COMPANY_C_POSITION.alt_m,
+        speed_mps=10.0,
+    )
+
+
+def _step_s6_send_to_brigade(roles: dict[str, _RoleBinding]) -> dict[str, Any]:
+    return roles["s6"].tools["send"]._run(
+        channel="HF",
+        message_payload={"type": "comms-status", "status": "green"},
+        recipient_role="BRIGADE_S6",
+        priority="ROUTINE",
+    )
+
+
+def _step_s6_report(roles: dict[str, _RoleBinding]) -> dict[str, Any]:
+    return roles["s6"].tools["report"]._run(
+        report_type="SITREP",
+        report_payload={
+            "comms": "nominal",
+            "ew_observed": False,
+            "channels_in_use": ["VHF", "HF"],
+        },
+        to_echelon="BRIGADE",
+    )
+
+
+# Order matters: S2 → S3 → companies (A → B → C) → S6.
+_BETWEEN_TURN_SCRIPT: Final[list[tuple[str, _StepFn]]] = [
+    ("s2.detect", _step_s2_detect),
+    ("s2.classify", _step_s2_classify),
+    ("s3.issue_order", _step_s3_issue_order_to_a),
+    ("s3.request_support", _step_s3_request_isr),
+    ("co_a.assume_posture", _step_co_a_assume_posture),
+    ("co_a.send", _step_co_a_send_sitrep),
+    ("co_b.halt", _step_co_b_halt),
+    ("co_b.suppress", _step_co_b_suppress),
+    ("co_c.move_to", _step_co_c_move),
+    ("s6.send", _step_s6_send_to_brigade),
+    ("s6.report", _step_s6_report),
+]
+
+
+def _orientation_anchors() -> dict[str, dict[str, float]]:
+    """Diagnostic hook for the README — surfaces the geographic anchors
+    the v1 script keys off of so a reader knows what 'BLUE-OP-1', etc.,
+    map to without grepping through doctrine.py."""
+    return {
+        "bn_hq": {"lat": WEST_BANK_BN_HQ.lat_deg, "lon": WEST_BANK_BN_HQ.lon_deg},
+        "op": {
+            "lat": WEST_BANK_OBSERVATION_POST.lat_deg,
+            "lon": WEST_BANK_OBSERVATION_POST.lon_deg,
+        },
+        "co_a": {"lat": COMPANY_A_POSITION.lat_deg, "lon": COMPANY_A_POSITION.lon_deg},
+        "co_b": {"lat": COMPANY_B_POSITION.lat_deg, "lon": COMPANY_B_POSITION.lon_deg},
+        "co_c": {"lat": COMPANY_C_POSITION.lat_deg, "lon": COMPANY_C_POSITION.lon_deg},
+        "nai_east": {
+            "lat": EAST_BANK_NAMED_AREA_OF_INTEREST.lat_deg,
+            "lon": EAST_BANK_NAMED_AREA_OF_INTEREST.lon_deg,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_blue_crew(crew_ctx: CrewContext) -> CrewResult:
+    """Execute one between-turn cycle for the blue battalion crew.
+
+    Self-contained: instantiates a fresh kernel DAG and validator,
+    builds the six agents bound to the us-bct profile, and runs the
+    deterministic 11-step script. Every step's tool call commits a
+    KernelEvent through ``NamespacedDag.commit()``.
+
+    Returns a :class:`CrewResult` with the events_committed count and
+    the per-step outcomes in metadata. Any step raising ``ToolError``
+    aborts the cycle and propagates to the caller.
+    """
+    started = time.perf_counter()
+    profile = load_us_bct_profile()
+    kernel_dag = NamespacedDag()
+    validator = Validator()
+
+    bindings = {
+        m.__name__.rsplit(".", 1)[-1]: _build_role(
+            m,
+            crew_ctx=crew_ctx,
+            capability_profile=profile,
+            kernel_dag=kernel_dag,
+            validator=validator,
+        )
+        for m in _ROLE_MODULES
+    }
+
+    step_outcomes: list[dict[str, Any]] = []
+    for label, step_fn in _BETWEEN_TURN_SCRIPT:
+        result = step_fn(bindings)
+        step_outcomes.append({"step": label, **result})
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+
+    return CrewResult(
+        crew="blue",
+        duration_ms=duration_ms,
+        notes=f"v1 deterministic blue crew — {len(step_outcomes)} events committed",
+        metadata={
+            "tenant_id": crew_ctx.tenant_id,
+            "scenario_id": crew_ctx.scenario_id,
+            "turn": crew_ctx.turn,
+            "events_committed": len(step_outcomes),
+            "steps": step_outcomes,
+            "validator_rejections": 0,  # any reject would have raised before reaching here
+            "anchors": _orientation_anchors(),
+        },
+    )
+
+
+# Convenience export so WS-401 can register `BLUE_CREWS["default"] =
+# BLUE_RUNNER` in a follow-up integration ticket.
+BLUE_RUNNER: Callable[[CrewContext], CrewResult] = run_blue_crew

--- a/agents/blue/src/almighty_blue_crew/doctrine.py
+++ b/agents/blue/src/almighty_blue_crew/doctrine.py
@@ -1,0 +1,71 @@
+"""Shared doctrine + Cumberland River geography for the blue crew.
+
+Constants, named coordinates, and short doctrinal notes used across the
+six agents' goals and backstories. Public, unclassified references only:
+
+  - FM 3-21.20 — The Infantry Battalion (US Army field manual).
+  - ATP 3-90.5 — Combined Arms Battalion.
+  - ATP 2-01.3 — Intelligence Preparation of the Battlefield.
+
+No specific real-world weapon system is named.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+# ---- Cumberland River anchor (per docs/architecture.md notional theater) -----
+
+NASHVILLE_LAT_DEG: Final[float] = 36.18
+NASHVILLE_LON_DEG: Final[float] = -86.78
+
+
+@dataclass(frozen=True)
+class NamedPoint:
+    name: str
+    lat_deg: float
+    lon_deg: float
+    alt_m: float
+
+
+# West-bank defensive positions. v1 uses notional but plausible offsets
+# from the river anchor. Not surveyed; do not use for actual operations.
+WEST_BANK_BN_HQ = NamedPoint(
+    name="BLUE-BN-HQ-1", lat_deg=36.1750, lon_deg=-86.7900, alt_m=170.0
+)
+WEST_BANK_OBSERVATION_POST = NamedPoint(
+    name="BLUE-OP-1", lat_deg=36.1820, lon_deg=-86.7860, alt_m=185.0
+)
+COMPANY_A_POSITION = NamedPoint(
+    name="BLUE-CO-A-1", lat_deg=36.1700, lon_deg=-86.7950, alt_m=170.0
+)
+COMPANY_B_POSITION = NamedPoint(
+    name="BLUE-CO-B-1", lat_deg=36.1780, lon_deg=-86.7900, alt_m=172.0
+)
+COMPANY_C_POSITION = NamedPoint(
+    name="BLUE-CO-C-1", lat_deg=36.1860, lon_deg=-86.7860, alt_m=175.0
+)
+EAST_BANK_NAMED_AREA_OF_INTEREST = NamedPoint(
+    name="NAI-EAST-CROSSING", lat_deg=36.1810, lon_deg=-86.7720, alt_m=160.0
+)
+
+# ---- Doctrinal flavor strings ----
+
+THEATER_BACKGROUND: Final[str] = (
+    "You are part of a US BCT battalion holding the west bank of the "
+    "Cumberland River north of Nashville. The notional opposing force "
+    "(red) is expected to attempt a forced crossing in the next several "
+    "turns. Your battalion's task is to detect the attempt early, "
+    "shape the engagement zone with indirect fires, and deny use of "
+    "the crossing. Civilian infrastructure on both banks is in scope; "
+    "non-combatant safety is a hard constraint adjudicated by the "
+    "white cell."
+)
+
+PUBLIC_DOCTRINE_REFERENCES: Final[str] = (
+    "Operate within the public doctrine of FM 3-21.20 (Infantry "
+    "Battalion), ATP 3-90.5 (Combined Arms Battalion), and ATP 2-01.3 "
+    "(Intelligence Preparation of the Battlefield). Do not invent or "
+    "name specific real-world weapon systems."
+)

--- a/agents/blue/src/almighty_blue_crew/profile.py
+++ b/agents/blue/src/almighty_blue_crew/profile.py
@@ -1,0 +1,27 @@
+"""Loader for the us-bct.json capability profile (WS-107).
+
+Self-contained so the crew can stand up without any caller-supplied
+profile fixture. The profile file lives at the canonical repo path; we
+resolve relative to this module's location.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+# agents/blue/src/almighty_blue_crew/profile.py -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_US_BCT_PATH = _REPO_ROOT / "kernel" / "capability-profiles" / "us-bct.json"
+
+
+@cache
+def load_us_bct_profile() -> dict[str, Any]:
+    """Return the us-bct.json capability profile as a dict.
+
+    Cached at process scope; the profile is immutable per WS-106 § 5.
+    """
+    with _US_BCT_PATH.open() as f:
+        return json.load(f)

--- a/agents/blue/src/almighty_blue_crew/s2.py
+++ b/agents/blue/src/almighty_blue_crew/s2.py
@@ -1,0 +1,37 @@
+"""S2 — Battalion Intelligence Officer.
+
+Fuses sensor artifacts, maintains the red common operational picture
+(COP), and issues priority-intelligence-requirement (PIR)-driven
+collection requests. Owns the four Sensor verbs.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .doctrine import PUBLIC_DOCTRINE_REFERENCES, THEATER_BACKGROUND
+
+ROLE: Final[str] = "S2 Intelligence Officer"
+
+GOAL: Final[str] = (
+    "Maintain a complete and current red common operational picture for "
+    "the battalion's area of operations: detect, track, classify, and "
+    "lose tracks on opposing-force entities, and surface priority "
+    "intelligence requirements (PIRs) for the S3 to action."
+)
+
+BACKSTORY: Final[str] = (
+    f"{THEATER_BACKGROUND}\n\n"
+    "You are the battalion S2. You consume reporting from organic and "
+    "attached sensors, fuse contacts into tracks, and refine tracks into "
+    "classifications when dwell allows. You do not directly affect "
+    "entities; your output drives the commander's decisions and the S3's "
+    "tasking. You issue collection requests by emitting `detect` and "
+    "`track` calls — `classify` only after sufficient dwell to meet the "
+    "modality's confidence floor.\n\n"
+    f"{PUBLIC_DOCTRINE_REFERENCES}"
+)
+
+ALLOWED_VERBS: Final[frozenset[str]] = frozenset(
+    {"detect", "track", "classify", "lose_track"}
+)

--- a/agents/blue/src/almighty_blue_crew/s3.py
+++ b/agents/blue/src/almighty_blue_crew/s3.py
@@ -1,0 +1,38 @@
+"""S3 — Battalion Operations Officer.
+
+Translates commander intent into orders, sequences effects, manages
+tempo. Owns the four Commander verbs (the Effector triggers themselves
+fire from company commanders, not from S3).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .doctrine import PUBLIC_DOCTRINE_REFERENCES, THEATER_BACKGROUND
+
+ROLE: Final[str] = "S3 Operations Officer"
+
+GOAL: Final[str] = (
+    "Translate commander intent into actionable orders for the "
+    "subordinate companies. Sequence effects in time and space so the "
+    "battalion can detect, shape, and engage red elements at the "
+    "Cumberland River crossing. Manage tempo so the S6 can keep comms "
+    "intact and the S2 has time to refine tracks before commitments."
+)
+
+BACKSTORY: Final[str] = (
+    f"{THEATER_BACKGROUND}\n\n"
+    "You are the battalion S3. Your tools are the four Commander verbs: "
+    "issue_order to direct subordinate companies, request_support for "
+    "fires/ISR/EW from higher echelon, delegate to expand a company's "
+    "verb authority for a window when the situation demands it, and "
+    "escalate when a decision exceeds your authority. You do not "
+    "directly call Effector verbs — that is companies' responsibility "
+    "once orders land.\n\n"
+    f"{PUBLIC_DOCTRINE_REFERENCES}"
+)
+
+ALLOWED_VERBS: Final[frozenset[str]] = frozenset(
+    {"issue_order", "request_support", "delegate", "escalate"}
+)

--- a/agents/blue/src/almighty_blue_crew/s6.py
+++ b/agents/blue/src/almighty_blue_crew/s6.py
@@ -1,0 +1,41 @@
+"""S6 — Battalion Signal Officer.
+
+Manages comms posture, responds to EW / jamming, reroutes traffic. Owns
+the four Communicator verbs.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .doctrine import PUBLIC_DOCTRINE_REFERENCES, THEATER_BACKGROUND
+
+ROLE: Final[str] = "S6 Signal Officer"
+
+GOAL: Final[str] = (
+    "Keep the battalion's comms paths intact under contested EW. "
+    "Maintain a posture that lets S2 reporting reach S3 and S3 orders "
+    "reach companies even when red is jamming. Reroute traffic when a "
+    "channel goes down; submit SITREPs and EW SPOTREPs so higher echelon "
+    "knows the comms picture."
+)
+
+BACKSTORY: Final[str] = (
+    f"{THEATER_BACKGROUND}\n\n"
+    "You are the battalion S6. Your tools are the four Communicator "
+    "verbs: send (point-to-point messages), relay (forwarding through "
+    "this entity), jam (denying red use of an RF band — defensive only "
+    "in this AOR), and report (structured status to higher echelon). "
+    "You do not pick fights you can avoid; comms degradation is a sign "
+    "to switch channels, not to escalate kinetically. The us-bct profile "
+    "does not authorize the jam verb — your defensive posture is built "
+    "around channel discipline, not active electronic attack.\n\n"
+    f"{PUBLIC_DOCTRINE_REFERENCES}"
+)
+
+# us-bct.json explicitly omits 'jam'; we declare the full Communicator
+# verb set here so the agent SHAPE is correct, but at run time the
+# capability gate in WS-402 will reject any 'jam' call by us-bct.
+ALLOWED_VERBS: Final[frozenset[str]] = frozenset(
+    {"send", "relay", "report"}
+)

--- a/agents/blue/tests/conftest.py
+++ b/agents/blue/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Test fixtures: a CrewContext with deterministic IDs."""
+
+from __future__ import annotations
+
+import pytest
+
+from almighty_agent_runtime.crews import CrewContext
+
+
+@pytest.fixture()
+def crew_ctx() -> CrewContext:
+    return CrewContext(
+        tenant_id="11111111-1111-4111-8111-111111111111",
+        scenario_id="22222222-2222-4222-8222-222222222222",
+        turn=1,
+    )

--- a/agents/blue/tests/test_crew.py
+++ b/agents/blue/tests/test_crew.py
@@ -1,0 +1,72 @@
+"""End-to-end test for the v1 deterministic blue crew (WS-403 DoD).
+
+The DoD: "crew runs one full between-turn cycle producing valid
+PyRapide events." This test runs ``run_blue_crew`` once and asserts:
+
+  - The crew completes (no ToolError raised).
+  - Every step's tool call was accepted (validator rejections == 0;
+    capability-gate misses would raise ToolError before reaching here).
+  - The KernelEvents produced cover all six roles' verbs in the
+    expected officer-type distribution.
+  - No two events share an event_id (UUID v4 collision sanity).
+"""
+
+from __future__ import annotations
+
+from almighty_blue_crew.crew import _BETWEEN_TURN_SCRIPT, run_blue_crew
+
+
+def test_crew_runs_one_full_cycle(crew_ctx):
+    result = run_blue_crew(crew_ctx)
+    assert result.crew == "blue"
+    assert result.duration_ms >= 0
+    assert result.metadata["events_committed"] == len(_BETWEEN_TURN_SCRIPT)
+    assert result.metadata["validator_rejections"] == 0
+    assert result.metadata["tenant_id"] == crew_ctx.tenant_id
+    assert result.metadata["scenario_id"] == crew_ctx.scenario_id
+    assert result.metadata["turn"] == crew_ctx.turn
+
+
+def test_every_step_has_an_event_id(crew_ctx):
+    result = run_blue_crew(crew_ctx)
+    event_ids = [step["event_id"] for step in result.metadata["steps"]]
+    assert len(event_ids) == len(set(event_ids)), "step event_ids must be unique"
+    assert all(eid for eid in event_ids), "every step must produce an event_id"
+
+
+def test_officer_type_distribution(crew_ctx):
+    """Six roles contribute to the run; the officer-type mix should
+    reflect the WS-105 verb-to-officer mapping."""
+    result = run_blue_crew(crew_ctx)
+    types = [step["officer_type"] for step in result.metadata["steps"]]
+    counts = {t: types.count(t) for t in set(types)}
+    # Sensor (S2): 2 events (detect + classify).
+    assert counts.get("SENSOR") == 2
+    # Commander (S3): 2 events (issue_order + request_support).
+    assert counts.get("COMMANDER") == 2
+    # Mover: 3 events (CO A assume_posture, CO B halt, CO C move_to).
+    assert counts.get("MOVER") == 3
+    # Effector: 1 event (CO B suppress).
+    assert counts.get("EFFECTOR") == 1
+    # Communicator: 3 events (CO A send + S6 send + S6 report).
+    assert counts.get("COMMUNICATOR") == 3
+    assert sum(counts.values()) == len(_BETWEEN_TURN_SCRIPT)
+
+
+def test_every_step_validator_field_set(crew_ctx):
+    """Every step result must declare validator outcome — 'accepted' for
+    CZML-emitting steps (Sensor.classify, Effector.suppress) and
+    'skipped' for non-spatial steps."""
+    result = run_blue_crew(crew_ctx)
+    accepted_or_skipped = {step["validator"] for step in result.metadata["steps"]}
+    assert accepted_or_skipped <= {"accepted", "skipped"}
+    # At least one accepted (means we exercised the validator path).
+    assert "accepted" in accepted_or_skipped
+
+
+def test_runner_export_is_callable(crew_ctx):
+    from almighty_blue_crew import BLUE_RUNNER
+
+    out = BLUE_RUNNER(crew_ctx)
+    assert out.crew == "blue"
+    assert out.metadata["events_committed"] == len(_BETWEEN_TURN_SCRIPT)


### PR DESCRIPTION
## Summary

Six CrewAI agents for a US BCT defending the Cumberland River west bank, all bound to `us-bct.json` (WS-107). Each agent is scoped to its officer types per WS-105:

| Role | Officer types | Verbs |
|---|---|---|
| **S2 Intelligence** | SENSOR | detect, track, classify, lose_track |
| **S3 Operations** | COMMANDER | issue_order, request_support, delegate, escalate |
| **S6 Signal** | COMMUNICATOR | send, relay, report (no `jam` — us-bct doesn't authorize) |
| **Co A** (left flank) | MOVER + EFFECTOR + COMMUNICATOR | move/engage/comms |
| **Co B** (center / main effort) | MOVER + EFFECTOR + COMMUNICATOR | covers crossing |
| **Co C** (right flank) | MOVER + EFFECTOR + COMMUNICATOR | upstream / repositions |

Goals/backstories key off public unclassified doctrine (FM 3-21.20, ATP 3-90.5, ATP 2-01.3) and Cumberland River geography. No specific real-world weapon system named.

Closes #23.

## What it is — and what it isn't

The v1 crew is **deterministic**. Each role is a real `crewai.Agent` with the proper `role`/`goal`/`backstory`/`tools` so the SHAPE matches what an LLM-driven loop will eventually need; the actual between-turn execution is a scripted 11-step Python sequence that calls each tool's `_run()` directly in the WS-105 order:

```
S2.detect → S2.classify
   → S3.issue_order → S3.request_support
   → Co A.assume_posture → Co A.send
   → Co B.halt → Co B.suppress
   → Co C.move_to
   → S6.send → S6.report
```

This satisfies the DoD ("crew runs one full between-turn cycle producing valid PyRapide events") without burning API keys or introducing nondeterminism. v2 swaps in `Crew.kickoff()` once LLM access / cost / latency budgets are sorted; the spec files are already shaped for it. The runbook explicitly calls this issue **stubs**.

## Layout

```
agents/blue/
├── pyproject.toml
├── README.md
├── src/almighty_blue_crew/
│   ├── profile.py             load_us_bct_profile (cached at process scope)
│   ├── doctrine.py            Cumberland River anchors + doctrine references
│   ├── s2.py / s3.py / s6.py  per-role spec modules (ROLE/GOAL/BACKSTORY/ALLOWED_VERBS)
│   ├── co_a.py / co_b.py / co_c.py
│   └── crew.py                run_blue_crew(ctx), BLUE_RUNNER, deterministic 11-step script
└── tests/                     5 passing
```

## Tests — 5 passing

```
$ pytest -v
tests/test_crew.py::test_crew_runs_one_full_cycle PASSED
tests/test_crew.py::test_every_step_has_an_event_id PASSED
tests/test_crew.py::test_officer_type_distribution PASSED
tests/test_crew.py::test_every_step_validator_field_set PASSED
tests/test_crew.py::test_runner_export_is_callable PASSED
5 passed in 3.35s
```

- **DoD test** (`test_crew_runs_one_full_cycle`) — one call → 11 events committed, zero validator rejections.
- **`test_officer_type_distribution`** — events split as scripted: 2 SENSOR / 2 COMMANDER / 3 MOVER / 1 EFFECTOR / 3 COMMUNICATOR.
- **`test_runner_export_is_callable`** — `BLUE_RUNNER` matches Shane's `CrewRunner = Callable[[CrewContext], CrewResult]` so the eventual WS-401 swap is a one-liner.

Tests use the **real** `NamespacedDag`, **real** `Validator`, **real** `OfficerToolBase` instances — no mocks. Drift in any upstream surfaces immediately on `pytest`.

## Definition of done check

- [x] All criteria from #23's Definition of done satisfied: crew runs one full between-turn cycle producing valid PyRapide events (no validator rejections in the happy path).
- [x] Documentation updated — README has the role table, sequence diagram, integration notes for WS-401, and rationale for the v1 deterministic shape.
- [x] Tests added or updated — 5 passing, real upstream deps (no mocks).
- [x] Banner present on any new visual surface — N/A (Python library).

## Decisions worth flagging

1. **Layout is `src/almighty_blue_crew/...`, not the runbook's flat `agents/blue/{s2,s3,...}.py`.** Matches Shane's WS-401 (`src/almighty_agent_runtime/`) and my WS-402 (`src/almighty_officer_tools/`). Standard packaging; flat layout would have mixed config/tests/code at the directory root.
2. **Crew is self-contained.** Instantiates a fresh `NamespacedDag` and `Validator` per call, generates synthetic per-role `agent_entity_id`s. Reason: Shane's `CrewContext` carries only `(tenant_id, scenario_id, turn)` — extending that contract from this PR would step into Shane's territory. Events committed during a v1 run are LOST when the function returns; that's the v1 stub bar (production, not persistence).
3. **No `disable` and no `jam` in any role's ALLOWED_VERBS.** us-bct.json doesn't include them. The capability gate in WS-402 would reject anyway, but pruning at the spec level keeps the agents' tool list honest.
4. **`destroy` is in companies' allowed set but the v1 script does NOT call it.** That path is reserved for the WS-405 adjudicator's `human_required = true` flow once the white cell is live.
5. **Don't wire into WS-401 in this PR.** The harness's `BLUE_CREWS["default"]` swap should land alongside WS-404 + WS-405 so all three crews go live together.
6. **CrewAI deprecation warnings during agent construction** — internal to crewai 1.14.3, not addressable from our side. Tests are clean otherwise.

## Downstream impact

- **Sibling work** WS-404 (#24) and WS-405 (#25) follow the same pattern: spec modules per role, deterministic v1 script, self-contained ctx. They can copy the layout.
- **Integration ticket** to file once all three crews exist: register `BLUE_RUNNER` / `RED_RUNNER` / `WHITE_RUNNER` in `agents/runtime/src/almighty_agent_runtime/crews.py`.
- **WS-601** (Nashville Cumberland River crossing scenario) will run all three crews per turn through the harness — this PR plus its two siblings are the substrate for that demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)