### PR TITLE
feat(renderer): white-cell control surface (WS-505)

### DIFF
--- a/web/renderer/src/api/whiteCell.ts
+++ b/web/renderer/src/api/whiteCell.ts
@@ -1,0 +1,210 @@
+// White-cell API surface. v1 mocks. The wire shapes match what
+// services/control-plane/ exposes (or will expose) so swapping the bodies
+// to real fetch() calls is a one-commit job per function.
+
+export type OverrideScope = "per-event" | "per-agent-per-turn" | "per-turn";
+export type OverrideAction = "review" | "auto-approve" | "auto-block";
+
+export interface OverridePolicy {
+  policy_id: string;
+  scope: OverrideScope;
+  target_id: string;
+  action: OverrideAction;
+  ttl_turns: number;
+  rationale: string;
+  created_at: string;
+}
+
+export interface PendingReviewItem {
+  event_id: string;
+  source_entity_id: string;
+  source_entity_name: string;
+  agent_id: string;
+  capability_profile_ref: string;
+  proposed_verb: string;
+  proposed_payload: Record<string, unknown>;
+  validator_result: "accepted" | "rejected" | "review";
+  human_required: boolean;
+  arrived_at: string;
+}
+
+export interface CapabilityProfile {
+  profile_id: string;
+  version: number;
+  display_name: string;
+  /** Full profile body. Keys defined in WS-106; renderer treats as opaque JSON. */
+  body: Record<string, unknown>;
+}
+
+// ---------- Turn advancement (WS-302) ----------
+
+export async function advanceTurn(): Promise<{ next_turn: number; snapshot_at: string }> {
+  // TODO WS-302 wiring: POST /tenants/:id/scenarios/:sid/turns/advance with
+  // the white-cell JWT. Endpoint returns the new turn number + snapshot ts.
+  await new Promise((r) => setTimeout(r, 600));
+  const snapshot_at = new Date().toISOString();
+  // eslint-disable-next-line no-console
+  console.log("[WS-505 stub] advance turn ←", snapshot_at);
+  return { next_turn: NEXT_TURN++, snapshot_at };
+}
+
+let NEXT_TURN = 4;
+
+// ---------- Override policies (WS-303) ----------
+
+const POLICIES: OverridePolicy[] = [
+  {
+    policy_id: "ovr-0001",
+    scope: "per-turn",
+    target_id: "3",
+    action: "auto-approve",
+    ttl_turns: 1,
+    rationale: "Routine sensor / mover traffic for turn 3 — pre-cleared by white cell.",
+    created_at: "2026-04-25T22:00:00Z",
+  },
+  {
+    policy_id: "ovr-0002",
+    scope: "per-event",
+    target_id: "evt-destroy-*",
+    action: "review",
+    ttl_turns: 0,
+    rationale: "Always review Effector.destroy events.",
+    created_at: "2026-04-25T22:01:00Z",
+  },
+];
+
+export async function listOverridePolicies(): Promise<OverridePolicy[]> {
+  await new Promise((r) => setTimeout(r, 80));
+  return [...POLICIES];
+}
+
+export async function createOverridePolicy(p: Omit<OverridePolicy, "policy_id" | "created_at">): Promise<OverridePolicy> {
+  // TODO WS-303 wiring: POST /tenants/:id/scenarios/:sid/overrides
+  await new Promise((r) => setTimeout(r, 150));
+  const created: OverridePolicy = {
+    ...p,
+    policy_id: `ovr-${crypto.randomUUID().slice(0, 4)}`,
+    created_at: new Date().toISOString(),
+  };
+  POLICIES.unshift(created);
+  // eslint-disable-next-line no-console
+  console.log("[WS-505 stub] create policy ←", created);
+  return created;
+}
+
+export async function revokeOverridePolicy(policy_id: string): Promise<void> {
+  // TODO WS-303 wiring: DELETE /tenants/:id/scenarios/:sid/overrides/:oid
+  await new Promise((r) => setTimeout(r, 120));
+  const idx = POLICIES.findIndex((p) => p.policy_id === policy_id);
+  if (idx >= 0) POLICIES.splice(idx, 1);
+  // eslint-disable-next-line no-console
+  console.log("[WS-505 stub] revoke policy ←", policy_id);
+}
+
+// ---------- Capability profiles (WS-107) ----------
+
+const PROFILES: CapabilityProfile[] = [
+  {
+    profile_id: "00000000-bbbb-0001-0000-000000000001",
+    version: 1,
+    display_name: "Notional US BCT — battalion",
+    body: {
+      profile_id: "00000000-bbbb-0001-0000-000000000001",
+      version: 1,
+      display_name: "Notional US BCT — battalion",
+      force_affiliation: "BLUE",
+      effect_parameter_ranges: {
+        radar_fan: { sweep_arc_deg: { min: 10, max: 360 }, range_m: { min: 500, max: 50000 } },
+      },
+      // ... other keys per WS-106. Truncated for the editor demo.
+    },
+  },
+  {
+    profile_id: "00000000-bbbb-0002-0000-000000000002",
+    version: 1,
+    display_name: "Notional peer adversary",
+    body: {
+      profile_id: "00000000-bbbb-0002-0000-000000000002",
+      version: 1,
+      display_name: "Notional peer adversary",
+      force_affiliation: "RED",
+      effect_parameter_ranges: {
+        jamming_circle: { radius_m: { min: 200, max: 8000 }, power_w: { min: 50, max: 1500 } },
+      },
+    },
+  },
+];
+
+export async function listProfiles(): Promise<CapabilityProfile[]> {
+  await new Promise((r) => setTimeout(r, 80));
+  return PROFILES.map((p) => ({ ...p, body: { ...p.body } }));
+}
+
+export async function saveProfile(p: CapabilityProfile): Promise<CapabilityProfile> {
+  // TODO WS-107 wiring: PATCH /tenants/:id/scenarios/:sid/profiles/:pid
+  // Profile authoring is pre-scenario only — the control plane should reject
+  // edits once turn >= 1. For v1 we surface the "locked" state in the UI but
+  // still accept the call so the demo loop is exercisable.
+  await new Promise((r) => setTimeout(r, 200));
+  const idx = PROFILES.findIndex((q) => q.profile_id === p.profile_id);
+  if (idx >= 0) PROFILES[idx] = p;
+  // eslint-disable-next-line no-console
+  console.log("[WS-505 stub] save profile ←", p.profile_id);
+  return p;
+}
+
+// ---------- Review queue (WS-303) ----------
+
+const PENDING: PendingReviewItem[] = [
+  {
+    event_id: "evt-0042",
+    source_entity_id: "00000000-0000-4000-8000-000000000005",
+    source_entity_name: "FSC mortar section",
+    agent_id: "blue.s3",
+    capability_profile_ref: "00000000-bbbb-0001-0000-000000000001@1",
+    proposed_verb: "engage",
+    proposed_payload: {
+      target_lat_deg: 36.198,
+      target_lon_deg: -86.762,
+      weapon_system: "notional.indirect.medium",
+      volume_count: 4,
+      intent: "NEUTRALIZE",
+    },
+    validator_result: "review",
+    human_required: false,
+    arrived_at: "2026-04-25T22:14:32Z",
+  },
+  {
+    event_id: "evt-0043",
+    source_entity_id: "00000000-0000-4000-8000-000000000002",
+    source_entity_name: "A/1-37 (CO A)",
+    agent_id: "blue.co_a",
+    capability_profile_ref: "00000000-bbbb-0001-0000-000000000001@1",
+    proposed_verb: "destroy",
+    proposed_payload: {
+      target_entity_id: "00000000-0000-4000-8000-000000000103",
+      weapon_system: "notional.indirect.medium",
+      volume_count: 8,
+      justification: "Confirmed EW emitter degrading 1-37 comms; CARVER score 21.",
+    },
+    validator_result: "review",
+    human_required: true,
+    arrived_at: "2026-04-25T22:15:01Z",
+  },
+];
+
+export type ReviewDecision = "approve" | "block" | "edit-and-approve" | "inject-manual";
+
+export async function listPendingReview(): Promise<PendingReviewItem[]> {
+  await new Promise((r) => setTimeout(r, 80));
+  return [...PENDING];
+}
+
+export async function decideReview(event_id: string, decision: ReviewDecision): Promise<void> {
+  // TODO WS-303 wiring: POST /tenants/:id/scenarios/:sid/events/:eid/decision
+  await new Promise((r) => setTimeout(r, 120));
+  const idx = PENDING.findIndex((p) => p.event_id === event_id);
+  if (idx >= 0) PENDING.splice(idx, 1);
+  // eslint-disable-next-line no-console
+  console.log("[WS-505 stub] decide", event_id, "→", decision);
+}

--- a/web/renderer/src/components/OverridePolicyPanel.tsx
+++ b/web/renderer/src/components/OverridePolicyPanel.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import {
+  type OverridePolicy,
+  type OverrideScope,
+  type OverrideAction,
+  createOverridePolicy,
+  listOverridePolicies,
+  revokeOverridePolicy,
+} from "../api/whiteCell";
+
+const SCOPES: OverrideScope[] = ["per-event", "per-agent-per-turn", "per-turn"];
+const ACTIONS: OverrideAction[] = ["review", "auto-approve", "auto-block"];
+
+export function OverridePolicyPanel() {
+  const [policies, setPolicies] = useState<OverridePolicy[]>([]);
+  const [scope, setScope] = useState<OverrideScope>("per-event");
+  const [targetId, setTargetId] = useState("");
+  const [action, setAction] = useState<OverrideAction>("review");
+  const [ttlTurns, setTtlTurns] = useState(0);
+  const [rationale, setRationale] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const refresh = () => void listOverridePolicies().then(setPolicies);
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const valid = targetId.trim().length > 0 && rationale.trim().length > 0;
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!valid || submitting) return;
+    setSubmitting(true);
+    try {
+      await createOverridePolicy({ scope, target_id: targetId.trim(), action, ttl_turns: ttlTurns, rationale: rationale.trim() });
+      setTargetId("");
+      setRationale("");
+      setTtlTurns(0);
+      refresh();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onRevoke = async (id: string) => {
+    await revokeOverridePolicy(id);
+    refresh();
+  };
+
+  return (
+    <section className="white-cell-section">
+      <h2>Override policies</h2>
+
+      <form className="override-form" onSubmit={onSubmit}>
+        <label className="override-form__row">
+          <span>Scope</span>
+          <select value={scope} onChange={(e) => setScope(e.target.value as OverrideScope)}>
+            {SCOPES.map((s) => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </label>
+        <label className="override-form__row">
+          <span>Target ID</span>
+          <input
+            type="text"
+            value={targetId}
+            placeholder={scope === "per-event" ? "event_id or pattern" : scope === "per-agent-per-turn" ? "agent_id:turn" : "turn"}
+            onChange={(e) => setTargetId(e.target.value)}
+          />
+        </label>
+        <label className="override-form__row">
+          <span>Action</span>
+          <select value={action} onChange={(e) => setAction(e.target.value as OverrideAction)}>
+            {ACTIONS.map((a) => <option key={a} value={a}>{a}</option>)}
+          </select>
+        </label>
+        <label className="override-form__row">
+          <span>TTL (turns)</span>
+          <input type="number" min={0} value={ttlTurns} onChange={(e) => setTtlTurns(Number(e.target.value))} />
+        </label>
+        <label className="override-form__row override-form__row--full">
+          <span>Rationale</span>
+          <textarea
+            rows={2}
+            value={rationale}
+            placeholder="Why this policy?"
+            onChange={(e) => setRationale(e.target.value)}
+          />
+        </label>
+        <button
+          type="submit"
+          className="white-cell-btn white-cell-btn--primary"
+          disabled={!valid || submitting}
+        >
+          {submitting ? "creating…" : "Create policy"}
+        </button>
+      </form>
+
+      <h3 className="white-cell-subhead">Active policies</h3>
+      {policies.length === 0 && <p className="white-cell-hint">No active policies.</p>}
+      <table className="policies-table">
+        <thead>
+          <tr>
+            <th>Scope</th>
+            <th>Target</th>
+            <th>Action</th>
+            <th>TTL</th>
+            <th>Rationale</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {policies.map((p) => (
+            <tr key={p.policy_id}>
+              <td><code>{p.scope}</code></td>
+              <td><code>{p.target_id}</code></td>
+              <td><span className={`pill pill--${p.action}`}>{p.action}</span></td>
+              <td>{p.ttl_turns}</td>
+              <td>{p.rationale}</td>
+              <td>
+                <button type="button" className="white-cell-btn white-cell-btn--danger" onClick={() => onRevoke(p.policy_id)}>
+                  revoke
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/web/renderer/src/components/ProfileEditor.tsx
+++ b/web/renderer/src/components/ProfileEditor.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import { type CapabilityProfile, listProfiles, saveProfile } from "../api/whiteCell";
+import type { TurnSnapshot } from "../api/mock";
+
+type ProfileEditorProps = {
+  turn: TurnSnapshot | null;
+};
+
+export function ProfileEditor({ turn }: ProfileEditorProps) {
+  const [profiles, setProfiles] = useState<CapabilityProfile[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [draftJson, setDraftJson] = useState<string>("");
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  // Profile authoring is pre-scenario only; locked once turn >= 1 per WS-106
+  // versioning rule. We surface the lock here but the stub still accepts the
+  // call so the demo loop is exercisable.
+  const locked = (turn?.current_turn ?? 0) >= 1;
+
+  useEffect(() => {
+    void listProfiles().then((p) => {
+      setProfiles(p);
+      if (p.length > 0) {
+        setSelectedId(p[0].profile_id);
+        setDraftJson(JSON.stringify(p[0].body, null, 2));
+      }
+    });
+  }, []);
+
+  const select = (id: string) => {
+    setSelectedId(id);
+    const p = profiles.find((q) => q.profile_id === id);
+    if (p) setDraftJson(JSON.stringify(p.body, null, 2));
+    setParseError(null);
+    setSavedAt(null);
+  };
+
+  const onSave = async () => {
+    const profile = profiles.find((q) => q.profile_id === selectedId);
+    if (!profile) return;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(draftJson);
+    } catch (err) {
+      setParseError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+    setParseError(null);
+    setSaving(true);
+    try {
+      const updated = await saveProfile({ ...profile, body: parsed });
+      setProfiles((prev) => prev.map((q) => (q.profile_id === updated.profile_id ? updated : q)));
+      setSavedAt(new Date().toISOString());
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="white-cell-section">
+      <h2>Capability profiles</h2>
+      {locked && (
+        <p className="white-cell-hint white-cell-hint--warn">
+          Scenario at turn {turn?.current_turn} — profile authoring is locked per WS-106 versioning rule. Edits forking a new profile_id only.
+        </p>
+      )}
+      <div className="profile-editor__row">
+        <select value={selectedId ?? ""} onChange={(e) => select(e.target.value)} className="profile-editor__select">
+          {profiles.map((p) => (
+            <option key={p.profile_id} value={p.profile_id}>
+              {p.display_name} (v{p.version})
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="white-cell-btn white-cell-btn--primary"
+          onClick={onSave}
+          disabled={saving || !selectedId}
+        >
+          {saving ? "saving…" : "Save profile"}
+        </button>
+      </div>
+      <textarea
+        className="profile-editor__textarea"
+        value={draftJson}
+        onChange={(e) => setDraftJson(e.target.value)}
+        spellCheck={false}
+        rows={14}
+      />
+      {parseError && <p className="white-cell-hint white-cell-hint--err">JSON parse error: {parseError}</p>}
+      {savedAt && !parseError && <p className="white-cell-hint">Saved at {savedAt}</p>}
+    </section>
+  );
+}

--- a/web/renderer/src/components/ReviewQueue.tsx
+++ b/web/renderer/src/components/ReviewQueue.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState, useCallback } from "react";
+import {
+  type PendingReviewItem,
+  type ReviewDecision,
+  decideReview,
+  listPendingReview,
+} from "../api/whiteCell";
+
+type ReviewQueueProps = {
+  /** When true, render only items flagged human_required=true (the WS-405 surface). */
+  humanRequiredOnly?: boolean;
+  title: string;
+  emptyMessage: string;
+};
+
+export function ReviewQueue({ humanRequiredOnly = false, title, emptyMessage }: ReviewQueueProps) {
+  const [items, setItems] = useState<PendingReviewItem[]>([]);
+  const [decidingId, setDecidingId] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    void listPendingReview().then((all) => {
+      setItems(humanRequiredOnly ? all.filter((i) => i.human_required) : all.filter((i) => !i.human_required));
+    });
+  }, [humanRequiredOnly]);
+
+  useEffect(refresh, [refresh]);
+
+  const decide = async (item: PendingReviewItem, decision: ReviewDecision) => {
+    setDecidingId(item.event_id);
+    try {
+      await decideReview(item.event_id, decision);
+      refresh();
+    } finally {
+      setDecidingId(null);
+    }
+  };
+
+  return (
+    <section className={`white-cell-section ${humanRequiredOnly ? "white-cell-section--adjudication" : ""}`}>
+      <h2>{title}</h2>
+      {items.length === 0 && <p className="white-cell-hint">{emptyMessage}</p>}
+      {items.map((item) => (
+        <div key={item.event_id} className="review-item">
+          <div className="review-item__header">
+            <span className="review-item__verb"><code>{item.proposed_verb}</code></span>
+            <span className="review-item__agent">{item.agent_id}</span>
+            <span className="review-item__time">{item.arrived_at}</span>
+          </div>
+          <div className="review-item__entity">
+            from <strong>{item.source_entity_name}</strong>
+            <span className="review-item__id"> ({item.source_entity_id.slice(0, 8)}…)</span>
+          </div>
+          <div className="review-item__profile">
+            profile: <code>{item.capability_profile_ref}</code> · validator: <code>{item.validator_result}</code>
+          </div>
+          <pre className="review-item__payload">{JSON.stringify(item.proposed_payload, null, 2)}</pre>
+          <div className="review-item__buttons">
+            <button
+              type="button"
+              className="white-cell-btn white-cell-btn--primary"
+              disabled={decidingId === item.event_id}
+              onClick={() => decide(item, "approve")}
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              className="white-cell-btn white-cell-btn--danger"
+              disabled={decidingId === item.event_id}
+              onClick={() => decide(item, "block")}
+            >
+              Block
+            </button>
+            <button
+              type="button"
+              className="white-cell-btn"
+              disabled={decidingId === item.event_id}
+              onClick={() => decide(item, "edit-and-approve")}
+            >
+              Edit + approve
+            </button>
+            <button
+              type="button"
+              className="white-cell-btn"
+              disabled={decidingId === item.event_id}
+              onClick={() => decide(item, "inject-manual")}
+            >
+              Inject manual
+            </button>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/web/renderer/src/components/TurnControls.tsx
+++ b/web/renderer/src/components/TurnControls.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { fetchTurnState, type TurnSnapshot } from "../api/mock";
+import { advanceTurn } from "../api/whiteCell";
+import { TurnState } from "./TurnState";
+
+export function TurnControls() {
+  const [snapshot, setSnapshot] = useState<TurnSnapshot | null>(null);
+  const [advancing, setAdvancing] = useState(false);
+  const [lastAdvanced, setLastAdvanced] = useState<string | null>(null);
+
+  useEffect(() => {
+    void fetchTurnState().then(setSnapshot);
+  }, []);
+
+  const onAdvance = async () => {
+    if (!snapshot || advancing) return;
+    setAdvancing(true);
+    setSnapshot({ ...snapshot, turn_state: "advancing" });
+    try {
+      const result = await advanceTurn();
+      setSnapshot({
+        current_turn: result.next_turn,
+        turn_state: "open",
+        last_advanced_at: result.snapshot_at,
+      });
+      setLastAdvanced(result.snapshot_at);
+    } finally {
+      setAdvancing(false);
+    }
+  };
+
+  const isAdvancing = snapshot?.turn_state === "advancing" || advancing;
+
+  return (
+    <section className="white-cell-section">
+      <h2>Turn advancement</h2>
+      <div className="turn-controls__row">
+        <TurnState snapshot={snapshot} />
+        <button
+          type="button"
+          className="white-cell-btn white-cell-btn--primary"
+          onClick={onAdvance}
+          disabled={isAdvancing}
+        >
+          {isAdvancing ? "advancing…" : "Advance turn"}
+        </button>
+      </div>
+      <p className="white-cell-hint">
+        Last snapshot: <code>{lastAdvanced ?? snapshot?.last_advanced_at ?? "—"}</code>
+      </p>
+    </section>
+  );
+}

--- a/web/renderer/src/router.tsx
+++ b/web/renderer/src/router.tsx
@@ -3,6 +3,7 @@ import { App } from "./App";
 import { ScenarioRoot } from "./routes/ScenarioRoot";
 import { Index } from "./routes/Index";
 import { ExconConsole } from "./routes/ExconConsole";
+import { WhiteCellConsole } from "./routes/WhiteCellConsole";
 
 export const router = createBrowserRouter([
   {
@@ -21,6 +22,10 @@ export const router = createBrowserRouter([
       {
         path: ":tenantId/scenarios/:scenarioId/excon/red",
         element: <ExconConsole side="red" />,
+      },
+      {
+        path: ":tenantId/scenarios/:scenarioId/white-cell",
+        element: <WhiteCellConsole />,
       },
       { path: "*", element: <Navigate to="/" replace /> },
     ],

--- a/web/renderer/src/routes/Index.tsx
+++ b/web/renderer/src/routes/Index.tsx
@@ -15,9 +15,12 @@ export function Index() {
         <li>
           <Link to="/demo/scenarios/demo/excon/red">demo / demo — EXCON red</Link>
         </li>
+        <li>
+          <Link to="/demo/scenarios/demo/white-cell">demo / demo — white cell control</Link>
+        </li>
       </ul>
       <p className="index__hint">
-        EXCON consoles require a JWT with the matching <code>cell_role</code>.
+        Operator consoles require a JWT with the matching <code>cell_role</code>.
         Append <code>?jwt=&lt;token&gt;</code> to the URL to set one.
       </p>
     </div>

--- a/web/renderer/src/routes/WhiteCellConsole.tsx
+++ b/web/renderer/src/routes/WhiteCellConsole.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useJwtClaims } from "../auth/jwt";
+import { AccessDenied } from "../components/AccessDenied";
+import { TurnControls } from "../components/TurnControls";
+import { OverridePolicyPanel } from "../components/OverridePolicyPanel";
+import { ProfileEditor } from "../components/ProfileEditor";
+import { ReviewQueue } from "../components/ReviewQueue";
+import { fetchTurnState, type TurnSnapshot } from "../api/mock";
+
+export function WhiteCellConsole() {
+  const { tenantId, scenarioId } = useParams<{ tenantId: string; scenarioId: string }>();
+  const claims = useJwtClaims();
+  const [turn, setTurn] = useState<TurnSnapshot | null>(null);
+
+  useEffect(() => {
+    void fetchTurnState().then(setTurn);
+  }, []);
+
+  if (!claims || claims.cell_role !== "white") {
+    return <AccessDenied required="white" actual={claims?.cell_role} />;
+  }
+
+  return (
+    <div className="white-cell">
+      <div className="white-cell__header">
+        <h1>White cell — control surface</h1>
+        <div className="white-cell__breadcrumb">
+          tenant <code>{tenantId}</code> · scenario <code>{scenarioId}</code>
+        </div>
+      </div>
+
+      <div className="white-cell__sections">
+        <TurnControls />
+        <OverridePolicyPanel />
+        <ProfileEditor turn={turn} />
+        <ReviewQueue
+          title="Override review queue"
+          emptyMessage="No events awaiting review."
+        />
+        <ReviewQueue
+          humanRequiredOnly
+          title="Adjudication — human required"
+          emptyMessage="No high-stakes events flagged by the adjudicator."
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/renderer/src/styles.css
+++ b/web/renderer/src/styles.css
@@ -408,3 +408,324 @@ body,
   color: #ff9090;
   border: 1px solid #8a4d4d;
 }
+
+/* ---------------- White cell console ---------------- */
+
+.white-cell {
+  height: 100%;
+  overflow-y: auto;
+  padding: 24px 32px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.white-cell__header {
+  margin-bottom: 24px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #333;
+}
+
+.white-cell__header h1 {
+  margin: 0;
+  font-size: 18px;
+  letter-spacing: 0.04em;
+  color: #eee;
+}
+
+.white-cell__breadcrumb {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #888;
+  font-family: ui-monospace, "SF Mono", monospace;
+}
+
+.white-cell__sections {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.white-cell-section {
+  background: #1f1f1f;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 16px 20px;
+}
+
+.white-cell-section--adjudication {
+  border-color: #8a4d4d;
+  background: rgba(60, 25, 25, 0.4);
+}
+
+.white-cell-section h2 {
+  margin: 0 0 12px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #999;
+}
+
+.white-cell-subhead {
+  margin: 16px 0 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #777;
+}
+
+.white-cell-hint {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: #888;
+}
+
+.white-cell-hint code {
+  color: #aaa;
+}
+
+.white-cell-hint--warn {
+  color: #ffb86c;
+}
+
+.white-cell-hint--err {
+  color: #ff8080;
+}
+
+.white-cell-btn {
+  padding: 6px 12px;
+  background: #2a2a2a;
+  color: #ccc;
+  border: 1px solid #444;
+  border-radius: 3px;
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.white-cell-btn:hover {
+  background: #333;
+  color: #fff;
+}
+
+.white-cell-btn--primary {
+  background: #2a4d6e;
+  color: #fff;
+  border-color: #4d6f8a;
+}
+
+.white-cell-btn--primary:not(:disabled):hover {
+  background: #335f88;
+}
+
+.white-cell-btn--danger {
+  background: #6e2a2a;
+  color: #fff;
+  border-color: #8a4d4d;
+}
+
+.white-cell-btn--danger:not(:disabled):hover {
+  background: #883535;
+}
+
+.white-cell-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.turn-controls__row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.override-form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 16px;
+  margin-bottom: 12px;
+}
+
+.override-form__row {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #ccc;
+}
+
+.override-form__row--full {
+  grid-column: 1 / -1;
+  grid-template-columns: 110px 1fr;
+}
+
+.override-form__row select,
+.override-form__row input,
+.override-form__row textarea {
+  background: #181818;
+  color: #eaeaea;
+  border: 1px solid #333;
+  border-radius: 3px;
+  padding: 4px 6px;
+  font-size: 12px;
+  font-family: inherit;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.override-form__row textarea {
+  resize: vertical;
+  min-height: 36px;
+}
+
+.override-form > .white-cell-btn {
+  grid-column: 1 / -1;
+  justify-self: start;
+}
+
+.policies-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.policies-table th,
+.policies-table td {
+  padding: 6px 8px;
+  text-align: left;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.policies-table th {
+  color: #888;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+}
+
+.policies-table td {
+  color: #ccc;
+}
+
+.policies-table code {
+  color: #aaa;
+}
+
+.pill {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-family: ui-monospace, "SF Mono", monospace;
+}
+
+.pill--review {
+  background: rgba(255, 184, 108, 0.2);
+  color: #ffb86c;
+}
+
+.pill--auto-approve {
+  background: rgba(80, 200, 120, 0.2);
+  color: #80d09c;
+}
+
+.pill--auto-block {
+  background: rgba(220, 80, 80, 0.2);
+  color: #ff9090;
+}
+
+.profile-editor__row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.profile-editor__select {
+  background: #181818;
+  color: #eaeaea;
+  border: 1px solid #333;
+  border-radius: 3px;
+  padding: 4px 6px;
+  font-size: 12px;
+  font-family: inherit;
+  flex: 1;
+}
+
+.profile-editor__textarea {
+  width: 100%;
+  background: #0f0f0f;
+  color: #d8d8d8;
+  border: 1px solid #333;
+  border-radius: 3px;
+  padding: 8px;
+  font-family: ui-monospace, "SF Mono", monospace;
+  font-size: 11px;
+  line-height: 1.45;
+  box-sizing: border-box;
+  resize: vertical;
+}
+
+.review-item {
+  background: #181818;
+  border: 1px solid #2a2a2a;
+  border-radius: 3px;
+  padding: 12px;
+  margin-bottom: 12px;
+}
+
+.review-item__header {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  font-size: 12px;
+  color: #ccc;
+  margin-bottom: 4px;
+}
+
+.review-item__verb code {
+  color: #8ec5ff;
+}
+
+.review-item__agent {
+  color: #888;
+  font-family: ui-monospace, "SF Mono", monospace;
+}
+
+.review-item__time {
+  margin-left: auto;
+  color: #666;
+  font-family: ui-monospace, "SF Mono", monospace;
+  font-size: 10px;
+}
+
+.review-item__entity,
+.review-item__profile {
+  font-size: 12px;
+  color: #aaa;
+  margin: 2px 0;
+}
+
+.review-item__id {
+  color: #666;
+  font-family: ui-monospace, "SF Mono", monospace;
+}
+
+.review-item__payload {
+  background: #0f0f0f;
+  border: 1px solid #2a2a2a;
+  border-radius: 3px;
+  padding: 8px;
+  font-size: 11px;
+  color: #ccc;
+  margin: 8px 0;
+  overflow-x: auto;
+}
+
+.review-item__buttons {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
## Summary
- New route \`/:tenantId/scenarios/:scenarioId/white-cell\`. Gated by \`cell_role=white\` via the JWT claims hook from WS-504; wrong role → ACCESS DENIED.
- Five vertical sections per spec:
  1. **Turn advancement** — Advance turn button + status badge (\`open\` / pulsing-orange \`advancing\` / \`open\`). POSTs against the WS-302 endpoint (stubbed).
  2. **Override policies** — author per-event / per-agent-per-turn / per-turn policies (WS-303 schema), active policies table with revoke action.
  3. **Capability profiles** — JSON textarea editor for the WS-107 profiles, parse-error surfacing, save flow. Shows the WS-106 "locked at turn ≥ 1" warning.
  4. **Override review queue** — incoming events on the override-pending channel, with Approve / Block / Edit-and-approve / Inject-manual buttons.
  5. **Adjudication — human required** — events flagged by the WS-405 white-cell adjudicator, visually distinct (red border).

## Hackathon stubs
All in \`src/api/whiteCell.ts\` with explicit \`TODO\` markers (\`WS-302\` for turn advance, \`WS-303\` for override policies + decisions, \`WS-107\` for profile saves). Wire shapes match what control-plane already exposes (or will). Each stub logs to \`console\` so the demo loop is exercisable now.

Closes #30.

## Test plan
- [ ] \`cd web/renderer && pnpm dev\`
- [ ] Visit \`/demo/scenarios/demo/white-cell?jwt=<WHITE>\` → five sections rendered, two seeded policies, two pending review items (one routine, one human-required)
- [ ] Create a policy (e.g., \`per-turn / 4 / auto-approve / 1 / "rationale"\`) → row appears
- [ ] Revoke a policy → row disappears
- [ ] Click Advance turn → "advancing…" → badge pulses → \`turn 4 OPEN\`; ProfileEditor warning appears
- [ ] Edit a profile JSON → Save → "Saved at …"; intentionally break JSON → red parse error
- [ ] Approve / Block items in both queues → they disappear
- [ ] BLUE token on \`/white-cell\` → ACCESS DENIED
- [ ] Browser console logs every action as \`[WS-505 stub] …\`