### PR TITLE
fix(renderer): replace JWT URL query param with dev token form

### DIFF
--- a/docs/better-late-than-never.md
+++ b/docs/better-late-than-never.md
@@ -466,6 +466,59 @@ Source: WS-101.
 
 ---
 
+## Renderer
+
+### `web/renderer/src/api/mock.ts` and `whiteCell.ts` are intentionally synthetic
+
+These two files exist to make the WS-504 (EXCON consoles) and WS-505
+(white-cell control surface) PRs reviewable + demoable *before* the
+upstream agent runtime (WS-402/403/404), live CZML adapter (WS-503), and
+some control-plane endpoints (turn snapshot fetch, profile editor)
+land. They contain:
+
+- Hardcoded fixture lists (5 BLUE entities, 4 RED entities, 2 seeded
+  override policies, 2 seeded review-queue items, 2 capability profiles).
+- Mutable module-level arrays (`POLICIES`, `PROFILES`, `PENDING`) that
+  survive across function calls within a page lifecycle.
+- A monotonic `NEXT_TURN++` counter for the Advance Turn stub.
+- `console.log("[WS-504/WS-505 stub] …")` entries on every action so the
+  demo loop is visible in DevTools.
+
+These are **deliberate hackathon artifacts**. The wire shapes match the
+real endpoints; integration is "delete the function body and replace
+with a `fetch()` call to control-plane." A code-review pass that flags
+mutable state, missing optimistic-UI rollback, magic-number turn
+counters, etc., is correct in the abstract but the right fix is
+**delete the file when wiring real APIs, not refactor it.**
+
+Don't write tests against these files; they're not the contract.
+
+Source: WS-504, WS-505 follow-up review pass.
+
+---
+
+### JWT in URL was a phishing vector — stripped in WS-505 follow-up
+
+Originally `useJwtClaims()` resolved the token from a `?jwt=<token>`
+query param (with localStorage fallback). Convenient for "paste this
+URL into the browser" demos. Bad shape: any link of the form
+`https://app/?jwt=<attacker-jwt>` would silently overwrite the
+victim's stored token with attacker-controlled claims (different
+tenant, escalated cell_role, etc.).
+
+The query-param flow was removed in the WS-505 follow-up. Tokens are
+now set via the `<DevTokenForm>` component mounted on the Index page
+and on the AccessDenied page — explicit user action, no URL-based
+side channel.
+
+If you're writing test instructions or docs that say "paste this URL,"
+update them to: "open `/`, fill the dev token form with the right
+cell_role, then navigate to the route."
+
+Source: WS-505 follow-up review pass.
+
+---
+
 ### Verify SVG banner artifacts before merging
 
 Diagram PRs should grep the SVG for the banner color and count the

--- a/web/renderer/src/auth/jwt.ts
+++ b/web/renderer/src/auth/jwt.ts
@@ -16,6 +16,7 @@ export interface JwtClaims {
 }
 
 const STORAGE_KEY = "almighty.jwt";
+const CELL_ROLES: readonly CellRole[] = ["white", "blue", "red", "observer"];
 
 function base64UrlDecode(input: string): string {
   const padded = input.padEnd(input.length + ((4 - (input.length % 4)) % 4), "=");
@@ -23,58 +24,72 @@ function base64UrlDecode(input: string): string {
   return atob(std);
 }
 
+function base64UrlEncode(s: string): string {
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
 export function decodeJwt(token: string): JwtClaims | null {
   try {
-    const [, payloadB64] = token.split(".");
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    const payloadB64 = parts[1];
     if (!payloadB64) return null;
     const payload = JSON.parse(base64UrlDecode(payloadB64)) as Partial<JwtClaims>;
     if (typeof payload.tenant_id !== "string") return null;
-    if (
-      payload.cell_role !== "white" &&
-      payload.cell_role !== "blue" &&
-      payload.cell_role !== "red" &&
-      payload.cell_role !== "observer"
-    ) {
-      return null;
-    }
+    if (!CELL_ROLES.includes(payload.cell_role as CellRole)) return null;
     return payload as JwtClaims;
   } catch {
     return null;
   }
 }
 
-// Resolves a token from (in priority order): ?jwt= query param (also persists
-// to localStorage), then localStorage. The query-param flow is a hackathon
-// convenience for demos; real auth lands in a future ticket.
-function resolveToken(): string | null {
-  if (typeof window === "undefined") return null;
-  const params = new URLSearchParams(window.location.search);
-  const fromQuery = params.get("jwt");
-  if (fromQuery) {
-    window.localStorage.setItem(STORAGE_KEY, fromQuery);
-    return fromQuery;
-  }
-  return window.localStorage.getItem(STORAGE_KEY);
+/**
+ * Mints an unsigned (`alg: "none"`) JWT for client-side dev use. The server
+ * will reject these — they're only good for the renderer's own route gating
+ * until a real auth flow lands.
+ */
+export function mintDevJwt(claims: JwtClaims): string {
+  const header = base64UrlEncode(JSON.stringify({ alg: "none", typ: "JWT" }));
+  const payload = base64UrlEncode(JSON.stringify(claims));
+  return `${header}.${payload}.`;
 }
 
-export function useJwtClaims(): JwtClaims | null {
-  const [claims, setClaims] = useState<JwtClaims | null>(() => {
-    const tok = resolveToken();
-    return tok ? decodeJwt(tok) : null;
-  });
+export function setStoredToken(token: string): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, token);
+  window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY, newValue: token }));
+}
 
-  useEffect(() => {
-    const onStorage = () => {
-      const tok = resolveToken();
-      setClaims(tok ? decodeJwt(tok) : null);
-    };
-    window.addEventListener("storage", onStorage);
-    return () => window.removeEventListener("storage", onStorage);
-  }, []);
-
-  return claims;
+export function clearStoredToken(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(STORAGE_KEY);
+  window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY, newValue: null }));
 }
 
 export function getStoredToken(): string | null {
   return typeof window === "undefined" ? null : window.localStorage.getItem(STORAGE_KEY);
+}
+
+/**
+ * Reads the JWT from localStorage only. v1 deliberately removed the
+ * `?jwt=<token>` URL flow — that was a phishing-shaped vector (any link
+ * could silently overwrite the stored token with attacker claims). Use
+ * the DevTokenForm to set a token instead.
+ */
+export function useJwtClaims(): JwtClaims | null {
+  const [claims, setClaims] = useState<JwtClaims | null>(() => {
+    const tok = getStoredToken();
+    return tok ? decodeJwt(tok) : null;
+  });
+
+  useEffect(() => {
+    const refresh = () => {
+      const tok = getStoredToken();
+      setClaims(tok ? decodeJwt(tok) : null);
+    };
+    window.addEventListener("storage", refresh);
+    return () => window.removeEventListener("storage", refresh);
+  }, []);
+
+  return claims;
 }

--- a/web/renderer/src/components/AccessDenied.tsx
+++ b/web/renderer/src/components/AccessDenied.tsx
@@ -1,5 +1,8 @@
+import { DevTokenForm } from "./DevTokenForm";
+import type { CellRole } from "../auth/jwt";
+
 type AccessDeniedProps = {
-  required: string;
+  required: CellRole;
   actual?: string;
 };
 
@@ -10,8 +13,9 @@ export function AccessDenied({ required, actual }: AccessDeniedProps) {
       <p>This route requires cell role: <strong>{required}</strong></p>
       <p>Your token: {actual ?? "<no token>"}</p>
       <p className="access-denied__hint">
-        Append <code>?jwt=&lt;your-token&gt;</code> to the URL to set a token.
+        Set a token with the matching role below — pages re-render once the token is stored.
       </p>
+      <DevTokenForm preselect={required} onSet={() => window.location.reload()} />
     </div>
   );
 }

--- a/web/renderer/src/components/DevTokenForm.tsx
+++ b/web/renderer/src/components/DevTokenForm.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import {
+  type CellRole,
+  clearStoredToken,
+  getStoredToken,
+  mintDevJwt,
+  setStoredToken,
+} from "../auth/jwt";
+
+const ROLES: readonly CellRole[] = ["white", "blue", "red", "observer"];
+const DEFAULT_TENANT = "11111111-1111-4111-8111-111111111111";
+
+type DevTokenFormProps = {
+  /** Which role this surface is asking for. Pre-selects the dropdown. */
+  preselect?: CellRole;
+  /** Where to land after a token is set. Defaults to current location. */
+  onSet?: () => void;
+};
+
+export function DevTokenForm({ preselect, onSet }: DevTokenFormProps) {
+  const [role, setRole] = useState<CellRole>(preselect ?? "white");
+  const [tenantId, setTenantId] = useState<string>(DEFAULT_TENANT);
+  const [storedPreview, setStoredPreview] = useState<string | null>(getStoredToken());
+
+  const apply = () => {
+    const token = mintDevJwt({ tenant_id: tenantId, cell_role: role });
+    setStoredToken(token);
+    setStoredPreview(token);
+    onSet?.();
+  };
+
+  const clear = () => {
+    clearStoredToken();
+    setStoredPreview(null);
+  };
+
+  return (
+    <div className="dev-token-form">
+      <h2>Dev token</h2>
+      <p className="dev-token-form__hint">
+        Mints an unsigned <code>alg:none</code> JWT and stores it in <code>localStorage</code>.
+        The server rejects these — they're only used by the renderer for client-side route gating.
+      </p>
+
+      <label className="dev-token-form__row">
+        <span>Cell role</span>
+        <select value={role} onChange={(e) => setRole(e.target.value as CellRole)}>
+          {ROLES.map((r) => (
+            <option key={r} value={r}>{r}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className="dev-token-form__row">
+        <span>Tenant ID</span>
+        <input type="text" value={tenantId} onChange={(e) => setTenantId(e.target.value)} />
+      </label>
+
+      <div className="dev-token-form__buttons">
+        <button type="button" className="white-cell-btn white-cell-btn--primary" onClick={apply}>
+          Set token
+        </button>
+        <button type="button" className="white-cell-btn" onClick={clear} disabled={!storedPreview}>
+          Clear token
+        </button>
+      </div>
+
+      {storedPreview && (
+        <p className="dev-token-form__preview">
+          stored: <code>{storedPreview.slice(0, 40)}…</code>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/renderer/src/routes/Index.tsx
+++ b/web/renderer/src/routes/Index.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { DevTokenForm } from "../components/DevTokenForm";
 
 export function Index() {
   return (
@@ -21,8 +22,9 @@ export function Index() {
       </ul>
       <p className="index__hint">
         Operator consoles require a JWT with the matching <code>cell_role</code>.
-        Append <code>?jwt=&lt;token&gt;</code> to the URL to set one.
+        Set one below before navigating.
       </p>
+      <DevTokenForm />
     </div>
   );
 }

--- a/web/renderer/src/styles.css
+++ b/web/renderer/src/styles.css
@@ -729,3 +729,65 @@ body,
   gap: 6px;
   flex-wrap: wrap;
 }
+
+/* ---------------- Dev token form ---------------- */
+
+.dev-token-form {
+  margin-top: 32px;
+  padding: 16px 20px;
+  background: #1f1f1f;
+  border: 1px solid #333;
+  border-radius: 4px;
+  max-width: 540px;
+}
+
+.dev-token-form h2 {
+  margin: 0 0 8px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #999;
+}
+
+.dev-token-form__hint {
+  font-size: 12px;
+  color: #888;
+  margin: 0 0 16px;
+}
+
+.dev-token-form__row {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 8px;
+  align-items: center;
+  font-size: 12px;
+  color: #ccc;
+  margin-bottom: 8px;
+}
+
+.dev-token-form__row select,
+.dev-token-form__row input {
+  background: #181818;
+  color: #eaeaea;
+  border: 1px solid #333;
+  border-radius: 3px;
+  padding: 4px 6px;
+  font-size: 12px;
+  font-family: inherit;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.dev-token-form__buttons {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.dev-token-form__preview {
+  margin-top: 12px;
+  font-size: 11px;
+  color: #888;
+  font-family: ui-monospace, "SF Mono", monospace;
+  word-break: break-all;
+}


### PR DESCRIPTION
## Summary
A code-review pass on WS-504/505 flagged the \`?jwt=<token>\` query-param flow in \`useJwtClaims()\` as a phishing-shaped vector — any link of the form \`https://app/?jwt=<attacker-jwt>\` would silently overwrite the victim's stored token with attacker-controlled claims (different tenant_id, escalated cell_role, etc.). This PR strips that path and replaces it with an explicit \`<DevTokenForm>\`.

### Changes
- \`src/auth/jwt.ts\` — removed query-param resolution; \`useJwtClaims()\` reads from \`localStorage\` only. Added \`mintDevJwt()\`, \`setStoredToken()\`, \`clearStoredToken()\`. Tightened \`decodeJwt()\` to require exactly 3 dot-separated segments.
- \`src/components/DevTokenForm.tsx\` — new UI: cell_role dropdown, tenant_id input, Set/Clear buttons, stored-token preview. Mints an unsigned (\`alg:none\`) JWT and writes it to \`localStorage\`.
- \`src/components/AccessDenied.tsx\` — embeds the form so users hitting a wrong-role gate can fix it in place.
- \`src/routes/Index.tsx\` — embeds the form so first-time users set a token before navigating.
- \`docs/better-late-than-never.md\` — two new entries:
  1. \`mock.ts\` and \`whiteCell.ts\` are intentional hackathon synthetics — to be deleted on integration, not refactored against future code-review nits.
  2. The JWT phishing-vector removal is documented so the team doesn't accidentally re-add a "paste this URL" shortcut.

### Test plan
- [ ] \`cd web/renderer && pnpm dev\`
- [ ] Visit \`/\` → see the dev token form on the index page
- [ ] DevTools → Local Storage → clear \`almighty.jwt\` → visit \`/demo/scenarios/demo/excon/blue\` → ACCESS DENIED page shows the dev token form pre-selected to \`blue\`
- [ ] Click **Set token** → page reloads → blue console renders
- [ ] Paste the EXCON URL with \`?jwt=<RED token>\` appended → still see the BLUE console (the \`?jwt=\` is ignored, no silent overwrite)