### PR TITLE
WS-405 — White-cell adjudicator agent

### DIFF
--- a/agents/white-cell/README.md
+++ b/agents/white-cell/README.md
@@ -1,0 +1,152 @@
+# `almighty-white-cell` — WS-405
+
+> **Classification:** UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY
+
+The white-cell adjudicator agent. Runs after blue (WS-403) and red
+(WS-404) crews complete in a between-turn cycle, classifies each
+pending event by stake, and proposes a resolution that the WS-303
+override gateway either commits (low / medium) or holds for human ack
+(high).
+
+## What it is
+
+A single agent — not a six-role staff like blue/red. The adjudicator
+sits outside the blue/red structure, doesn't issue officer verbs (its
+tool-set is empty), and reads events emitted by the other crews. Its
+output is one :class:`Decision` per input event, mapping onto the
+WS-303 ``override_decisions`` audit table:
+
+| Decision field | Meaning |
+|---|---|
+| `event_id` | UUID of the source event being adjudicated. |
+| `action_verb`, `source_officer_type` | Echoed from the source for AAR readability. |
+| `stake` | `low` / `medium` / `high`. See [§ Stake heuristic](#stake-heuristic). |
+| `outcome` | `auto-approve` (low/medium) or `review-pending` (high). |
+| `human_required` | `True` for `review-pending`. |
+| `contested` | `True` when the event conflicts with another event in the same turn. |
+| `rationale` | Human-readable explanation, written to the audit row. |
+| `conflicts_with` | Event IDs this decision is contested against. |
+
+## Stake heuristic
+
+v1 default (override via the `stake_predicate` argument):
+
+| Stake | Trigger |
+|---|---|
+| **high** | `action_verb == 'destroy'` (always). OR `payload.stake == 'high'` (stamped by the WS-402 `DestroyTool` and any future high-stakes emitter). OR adjudication-flagged verb (`engage`, `disable`, `jam`) when target/area is sensitive: `target_force_affiliation == 'NEUTRAL'`, `target_is_civilian == True`, `population_center == True`, or `civilian_band_overlap == True`. |
+| **medium** | Effector + EW area effects without sensitive-target signals (`engage`, `suppress`, `jam`, `disable`). |
+| **low** | Sensor reads, Mover position changes, Communicator messages (non-EW), Commander orders / requests / delegations / escalations. |
+
+> **Why not "destroy on a population center"?** The runbook hints that as the high-stakes default, but WS-101's entity schema does not yet carry a `population_center` flag (an open question I flagged in the WS-108 review). v1 surfaces the runbook's intent through caller-annotated payload fields (`target_is_civilian`, `target_force_affiliation`, `population_center`) instead. The Nashville WS-601 scenario will likely supply a custom `StakePredicate` that consults a named-area-of-interest map.
+
+The high-stakes path is the **contract** — a custom predicate may broaden it but should never downgrade an obviously-high event without scenario-specific reason. Tests confirm a `destroy` event that's also `contested` still routes to `review-pending` (high stake wins).
+
+## Contested-effect detection
+
+The default `contested_predicate` flags an event as contested when:
+
+1. `payload.contested == True` (caller-set marker), OR
+2. `payload.adjudication_state == 'contested'` (per WS-108 § 2 enum), OR
+3. Another event in the same batch targets the same `target_entity_id` from the same turn.
+
+(3) catches the canonical "did the EW cone actually degrade comms?" case the runbook calls out — overlapping claims on the same target entity. The adjudicator emits **one Decision per event** (not one merged); each contested event names its conflicts via `conflicts_with`.
+
+## API contract
+
+```python
+from almighty_kernel.dag import KernelEvent
+from almighty_white_cell import adjudicate_events, Decision
+
+events: list[KernelEvent] = ...  # union of blue + red commits this turn
+decisions: list[Decision] = adjudicate_events(events)
+
+# Or with a custom heuristic:
+def my_stake(e):
+    if "OBJ-CIVILIAN" in e.payload.get("target_label", ""):
+        return "high"
+    return "medium" if e.action_verb in ("engage", "suppress") else "low"
+
+decisions = adjudicate_events(events, stake_predicate=my_stake)
+```
+
+For harness integration, the convenience runner matches Shane's `CrewRunner` signature:
+
+```python
+from almighty_agent_runtime.crews import CrewContext
+from almighty_white_cell import run_white_crew
+
+result = run_white_crew(CrewContext(tenant_id="...", scenario_id="...", turn=1))
+# CrewResult(crew='white', metadata={'events_in': 6, 'decisions': [...], ...})
+```
+
+The v1 runner manufactures a synthetic 6-event batch (3 routine + 2 contested-pair + 1 high-stakes destroy) so the harness can exercise both DoD scenarios end-to-end without depending on a queue surface that WS-401 doesn't expose yet. v2 will pull pending events from the harness queue.
+
+## Integration with WS-303 override gateway
+
+In v1 the adjudicator does **not** POST decisions to the control-plane HTTP service — it returns Decisions and lets the caller wire them. When the integration ticket lands (after all three crews are merged), the caller will:
+
+1. For each Decision with `outcome == 'auto-approve'`: the gateway's `evaluateEvent` already returns `auto-approve`, no extra POST needed.
+2. For each Decision with `outcome == 'review-pending'`: POST to `POST /tenants/:id/scenarios/:sid/events/:eid/decision` per WS-303, but using `outcome = 'review-pending'` to signal human review needed (the adjudicator is the producer; the white cell operator via WS-505 is the eventual decider).
+
+Until that integration, the v1 runner's metadata.decisions list is the contract surface — anyone consuming it gets the same shape the gateway will eventually persist.
+
+## Run
+
+```bash
+# From this directory (agents/white-cell/):
+python3.13 -m venv .venv
+source .venv/bin/activate
+
+# Install editable deps in topological order:
+pip install -e ../../kernel
+pip install -e ../runtime
+pip install -e ".[dev]"
+
+# Run the test suite:
+pytest -v
+```
+
+## Tests — 25 passing
+
+- **`test_stakes.py`** (12 tests): stake_level for every verb and sensitive-target signal — destroy always high, payload markers, neutral / civilian / civilian-band overlap, medium/low defaults.
+- **`test_adjudicator.py`** (7 tests): per-decision flow — auto-approve for low; review-pending + human_required for high; contested-pair yields two Decisions with mutual conflicts_with; high-stakes-AND-contested still holds for human ack; custom stake predicate honored; decision order matches event order.
+- **`test_crew.py`** (6 tests): end-to-end via `run_white_crew(ctx)` against the synthetic 6-event batch — confirms both DoD scenarios (contested-pair + high-stakes destroy holds for human ack), routine events auto-approve, runner export is callable.
+
+Real `KernelEvent` instances throughout — no mocks of upstream contracts.
+
+## Layout
+
+```
+agents/white-cell/
+├── pyproject.toml
+├── README.md                                     ← this file
+├── src/almighty_white_cell/
+│   ├── __init__.py                               ← exports adjudicate_events, Decision, stake_level, WHITE_RUNNER
+│   ├── stakes.py                                 ← stake_level(event), StakePredicate type
+│   ├── adjudicator.py                            ← Decision, adjudicate_events(events, *, stake_predicate, contested_predicate)
+│   └── crew.py                                   ← run_white_crew(ctx), WHITE_RUNNER, synthetic event batch
+└── tests/
+    ├── conftest.py                               ← crew_ctx fixture, make_event helper
+    ├── test_stakes.py
+    ├── test_adjudicator.py
+    └── test_crew.py
+```
+
+## Notes / open questions
+
+- **No HTTP integration with the override gateway in this PR.** The adjudicator returns Decisions; wiring them to the WS-303 service is a follow-up (matches the same scope-discipline I've used for blue / red crew → WS-401 harness).
+- **No `population_center` lookup.** WS-101 entity schema lacks the field; v1 reads caller-annotated payload signals. The scenario-specific predicate is the right escape hatch until an entity-side flag lands.
+- **Adjudicator is single-agent, not a Crew.** The `_build_adjudicator_agent` constructor returns one `crewai.Agent` for parity with blue / red. There's no `crewai.Crew` constructed in v1 because the adjudicator doesn't run a multi-agent process.
+- **v1 doesn't read events from the harness queue.** It manufactures a synthetic batch in `_synthetic_events`. v2 will replace this with a pull from the WS-401 harness's commit queue once that queue surface exists.
+- **Empty tool-set is intentional.** The adjudicator does not issue officer verbs. Its output is the Decision list, written to `override_decisions` by the gateway.
+
+## See also
+
+- [`docs/schema/officer-interfaces.md`](../../docs/schema/officer-interfaces.md) — verb signatures (WS-105).
+- [`docs/schema/artifacts.md`](../../docs/schema/artifacts.md) — adjudication state machine + flow categories (WS-108 § 2-3).
+- [`services/control-plane/`](../../services/control-plane/) — override gateway (WS-303).
+- [`services/control-plane/migrations/1763676000003_override-policies.sql`](../../services/control-plane/migrations/1763676000003_override-policies.sql) — the `override_decisions` table this agent's Decisions map onto.
+- [`agents/blue/`](../blue/) — WS-403 blue crew.
+- [`agents/red/`](../red/) — WS-404 red crew.
+- WS-505 (#30) — white-cell console where human operators act on `review-pending` decisions.
+- WS-601 (#32) — Nashville scenario; will supply a scenario-specific `stake_predicate`.

--- a/agents/white-cell/pyproject.toml
+++ b/agents/white-cell/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "almighty-white-cell"
+version = "0.1.0"
+description = "Almighty white-cell adjudicator agent (WS-405)"
+requires-python = ">=3.11"
+authors = [{ name = "Almighty Team" }]
+dependencies = [
+    "crewai>=0.95",
+    "pydantic>=2.6",
+    "almighty-agent-runtime",
+    "almighty-kernel",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["almighty_white_cell*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/agents/white-cell/src/almighty_white_cell/__init__.py
+++ b/agents/white-cell/src/almighty_white_cell/__init__.py
@@ -1,0 +1,30 @@
+"""Almighty white-cell adjudicator agent (WS-405).
+
+A single agent that runs after blue and red crews complete, reads the
+turn's pending events, computes a stake level per event, and proposes
+a resolution:
+
+  high stakes   -> outcome='review-pending', human_required=True
+                   (the override gateway holds the event until a white
+                    cell operator clicks through via WS-505)
+  low / medium  -> outcome='auto-approve', human_required=False
+                   (the override gateway commits with the proposed
+                    rationale stamped on the audit row)
+
+See README.md for the v1 stake heuristic and the contract with the
+WS-303 override gateway.
+"""
+
+from .adjudicator import Decision, adjudicate_events
+from .crew import WHITE_RUNNER, run_white_crew
+from .stakes import StakeLevel, StakePredicate, stake_level
+
+__all__ = [
+    "Decision",
+    "adjudicate_events",
+    "stake_level",
+    "StakeLevel",
+    "StakePredicate",
+    "run_white_crew",
+    "WHITE_RUNNER",
+]

--- a/agents/white-cell/src/almighty_white_cell/adjudicator.py
+++ b/agents/white-cell/src/almighty_white_cell/adjudicator.py
@@ -1,0 +1,187 @@
+"""Adjudicator core.
+
+Reads a turn's worth of pending events, computes per-event stake and
+contested-ness, and proposes one :class:`Decision` per event.
+
+A Decision maps onto the WS-303 override-gateway outcome enum:
+
+  high          -> outcome='review-pending', human_required=True
+  low / medium  -> outcome='auto-approve',  human_required=False
+
+In v1 the adjudicator does NOT POST to the control-plane HTTP service
+(WS-303). Returning Decisions and letting the caller wire them to the
+gateway is the v1 contract; HTTP integration is a follow-up.
+
+Contested events get one Decision with ``contested=True`` and a
+rationale that names the conflicting event(s). The runbook's
+"propose a single proposed_resolution per contested effect" is honored
+by yielding exactly one Decision per source event regardless of how
+many other events it conflicts with.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Literal
+from uuid import UUID
+
+from almighty_kernel.dag import KernelEvent
+
+from .stakes import StakeLevel, StakePredicate, stake_level
+
+DecisionOutcome = Literal["auto-approve", "review-pending"]
+ContestedPredicate = Callable[[KernelEvent, list[KernelEvent]], bool]
+
+
+@dataclass(frozen=True)
+class Decision:
+    """One adjudicator-proposed outcome for one event.
+
+    Maps onto a row the WS-303 override gateway would write into
+    ``override_decisions`` (see services/control-plane/migrations/
+    1763676000003_override-policies.sql).
+    """
+
+    event_id: UUID
+    action_verb: str
+    source_officer_type: str
+    stake: StakeLevel
+    outcome: DecisionOutcome
+    human_required: bool
+    contested: bool
+    rationale: str
+    conflicts_with: list[UUID] = field(default_factory=list)
+
+
+# ---- Default contested predicate ---------------------------------------------
+
+
+def _default_contested_predicate(
+    event: KernelEvent, all_events: list[KernelEvent]
+) -> bool:
+    """Default v1 heuristic. An event is contested when:
+
+      (a) its payload carries an explicit ``contested = True`` marker, OR
+      (b) its payload's ``adjudication_state == 'contested'`` (per
+          WS-108 § 2 enum), OR
+      (c) another event in the same batch targets the same
+          ``target_entity_id`` from the same turn.
+
+    (c) catches the canonical case the runbook calls out — "did the EW
+    cone actually degrade comms?" — by detecting overlapping claims on
+    the same target.
+    """
+    if event.payload.get("contested") is True:
+        return True
+    if event.payload.get("adjudication_state") == "contested":
+        return True
+    target = event.payload.get("target_entity_id")
+    if not target:
+        return False
+    for other in all_events:
+        if other.event_id == event.event_id:
+            continue
+        if other.payload.get("target_entity_id") == target and other.turn == event.turn:
+            return True
+    return False
+
+
+def _conflicts_for(
+    event: KernelEvent, all_events: list[KernelEvent]
+) -> list[UUID]:
+    """List the event_ids that conflict with this one (same target,
+    same turn). Used to populate ``Decision.conflicts_with`` so AAR can
+    render the contested set."""
+    target = event.payload.get("target_entity_id")
+    if not target:
+        return []
+    return [
+        other.event_id
+        for other in all_events
+        if other.event_id != event.event_id
+        and other.payload.get("target_entity_id") == target
+        and other.turn == event.turn
+    ]
+
+
+# ---- Public entry point ------------------------------------------------------
+
+
+def adjudicate_events(
+    events: list[KernelEvent],
+    *,
+    stake_predicate: StakePredicate | None = None,
+    contested_predicate: ContestedPredicate | None = None,
+) -> list[Decision]:
+    """Return one Decision per event, in the order events were given.
+
+    Args:
+        events: pending events from this turn (typically the union of
+            blue and red crew commits).
+        stake_predicate: override the default stake heuristic. The
+            high-stakes path is the contract; even a custom predicate
+            should not downgrade an obviously-high event without a
+            clear scenario reason.
+        contested_predicate: override the default contested detection.
+    """
+    stake_fn = stake_predicate or stake_level
+    contested_fn = contested_predicate or _default_contested_predicate
+
+    decisions: list[Decision] = []
+    for event in events:
+        stake: StakeLevel = stake_fn(event)
+        contested = contested_fn(event, events)
+        if stake == "high":
+            outcome: DecisionOutcome = "review-pending"
+            human_required = True
+            rationale = _high_stakes_rationale(event, contested)
+        else:
+            outcome = "auto-approve"
+            human_required = False
+            rationale = _low_or_medium_rationale(event, stake, contested)
+        decisions.append(
+            Decision(
+                event_id=event.event_id,
+                action_verb=event.action_verb,
+                source_officer_type=event.source_officer_type,
+                stake=stake,
+                outcome=outcome,
+                human_required=human_required,
+                contested=contested,
+                rationale=rationale,
+                conflicts_with=_conflicts_for(event, events),
+            )
+        )
+    return decisions
+
+
+# ---- Rationale builders ------------------------------------------------------
+
+
+def _high_stakes_rationale(event: KernelEvent, contested: bool) -> str:
+    parts: list[str] = [
+        f"high-stakes verb '{event.action_verb}' from {event.source_officer_type}",
+    ]
+    if event.payload.get("stake") == "high":
+        parts.append("emitter stamped payload.stake='high'")
+    if event.payload.get("target_force_affiliation") == "NEUTRAL":
+        parts.append("target is NEUTRAL force")
+    if event.payload.get("target_is_civilian") or event.payload.get("population_center"):
+        parts.append("target is civilian / population center")
+    if event.payload.get("civilian_band_overlap"):
+        parts.append("EW band overlaps declared civilian frequency")
+    if contested:
+        parts.append("contested with other events in the same turn")
+    parts.append("holding for human ack via WS-303 review-pending state")
+    return "; ".join(parts)
+
+
+def _low_or_medium_rationale(
+    event: KernelEvent, stake: StakeLevel, contested: bool
+) -> str:
+    parts = [f"{stake}-stakes verb '{event.action_verb}'"]
+    if contested:
+        parts.append("contested but not high-stakes; auto-approving with audit")
+    else:
+        parts.append("routine path")
+    return "; ".join(parts)

--- a/agents/white-cell/src/almighty_white_cell/crew.py
+++ b/agents/white-cell/src/almighty_white_cell/crew.py
@@ -1,0 +1,236 @@
+"""White-cell crew runner — plugs into WS-401's harness.
+
+The white-cell adjudicator is a single agent (not a six-role staff
+like blue/red). For the v1 stub, ``run_white_crew(ctx)``:
+
+  1. Builds a real ``crewai.Agent`` for the adjudicator (proper role /
+     goal / backstory / tool-set is empty — the adjudicator does not
+     issue officer verbs).
+  2. Manufactures a synthetic batch of events that would, in a real
+     turn, come from blue + red commit logs. v1's batch is hardcoded
+     to exercise both DoD scenarios:
+       - a contested-effect pair (blue / red events on the same target)
+       - a high-stakes destroy event that must hold for human ack.
+  3. Calls :func:`adjudicate_events` and stamps the per-event
+     decisions into the CrewResult metadata.
+
+The ``ctx`` (tenant_id, scenario_id, turn) flows into the manufactured
+events so committed audit rows are correctly namespaced when the v2
+integration writes them to the override gateway.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable
+from uuid import UUID, uuid4
+
+from almighty_agent_runtime.crews import CrewContext, CrewResult
+from almighty_kernel.dag import KernelEvent
+from crewai import Agent
+
+from .adjudicator import Decision, adjudicate_events
+
+ROLE = "White Cell Adjudicator"
+
+GOAL = (
+    "Resolve contested or ambiguous effects committed during the "
+    "between-turn cycle. Auto-approve routine outcomes; hold high-"
+    "stakes events for human ack via the WS-303 override gateway."
+)
+
+BACKSTORY = (
+    "You are the white-cell adjudicator. You sit outside the blue/red "
+    "structure and have cross-tenant visibility within your tenant. "
+    "You read the turn's pending events, classify each by stake, and "
+    "propose a resolution that the override gateway will either commit "
+    "(low/medium) or hold for human review (high). You do not issue "
+    "officer verbs yourself; your tool-set is empty. Your output is "
+    "the proposed_resolution decisions returned to the harness."
+)
+
+
+def _build_adjudicator_agent() -> Agent:
+    """Construct the adjudicator agent shape. v1 deterministic crew
+    never calls Crew.kickoff(), so no LLM is configured."""
+    return Agent(
+        role=ROLE,
+        goal=GOAL,
+        backstory=BACKSTORY,
+        tools=[],  # adjudicator does not issue officer verbs
+        allow_delegation=False,
+        verbose=False,
+        llm=None,
+    )
+
+
+# ---- v1 synthetic event manufacturing ---------------------------------------
+
+
+def _synthetic_events(crew_ctx: CrewContext) -> list[KernelEvent]:
+    """Manufacture a 5-event batch that exercises both DoD scenarios.
+
+    Events 1-3: routine activity (Sensor.detect, Mover.move_to,
+    Communicator.send) — should auto-approve.
+
+    Events 4-5: a contested pair — blue Effector.engage and red
+    Effector.engage targeting the same entity in the same turn.
+    Default contested predicate fires on (c) shared target_entity_id.
+
+    Event 6: a high-stakes destroy — payload.stake='high' (per WS-402
+    DestroyTool stamping). Must hold for human ack regardless of
+    contested-ness.
+    """
+    tenant_id = UUID(crew_ctx.tenant_id)
+    scenario_id = UUID(crew_ctx.scenario_id)
+    turn = crew_ctx.turn
+
+    blue_entity = uuid4()
+    red_entity = uuid4()
+    contested_target = uuid4()
+    civilian_pop_center = uuid4()
+
+    return [
+        KernelEvent(
+            event_id=uuid4(),
+            tenant_id=tenant_id,
+            scenario_id=scenario_id,
+            turn=turn,
+            source_officer_type="SENSOR",
+            source_entity_id=blue_entity,
+            action_verb="detect",
+            payload={"modality": "RADAR", "confidence": 0.9, "range_m": 8000},
+            causal_predecessors=[],
+        ),
+        KernelEvent(
+            event_id=uuid4(),
+            tenant_id=tenant_id,
+            scenario_id=scenario_id,
+            turn=turn,
+            source_officer_type="MOVER",
+            source_entity_id=red_entity,
+            action_verb="move_to",
+            payload={"target_lat_deg": 36.18, "target_lon_deg": -86.78},
+            causal_predecessors=[],
+        ),
+        KernelEvent(
+            event_id=uuid4(),
+            tenant_id=tenant_id,
+            scenario_id=scenario_id,
+            turn=turn,
+            source_officer_type="COMMUNICATOR",
+            source_entity_id=blue_entity,
+            action_verb="send",
+            payload={"channel": "VHF", "priority": "ROUTINE"},
+            causal_predecessors=[],
+        ),
+        # Contested pair (events 4 + 5):
+        KernelEvent(
+            event_id=uuid4(),
+            tenant_id=tenant_id,
+            scenario_id=scenario_id,
+            turn=turn,
+            source_officer_type="EFFECTOR",
+            source_entity_id=blue_entity,
+            action_verb="engage",
+            payload={
+                "weapon_system": "notional.indirect.medium",
+                "target_entity_id": str(contested_target),
+                "intent": "NEUTRALIZE",
+            },
+            causal_predecessors=[],
+        ),
+        KernelEvent(
+            event_id=uuid4(),
+            tenant_id=tenant_id,
+            scenario_id=scenario_id,
+            turn=turn,
+            source_officer_type="EFFECTOR",
+            source_entity_id=red_entity,
+            action_verb="engage",
+            payload={
+                "weapon_system": "notional.indirect.medium",
+                "target_entity_id": str(contested_target),
+                "intent": "SUPPRESS_AND_HOLD",
+            },
+            causal_predecessors=[],
+        ),
+        # High-stakes destroy (event 6):
+        KernelEvent(
+            event_id=uuid4(),
+            tenant_id=tenant_id,
+            scenario_id=scenario_id,
+            turn=turn,
+            source_officer_type="EFFECTOR",
+            source_entity_id=blue_entity,
+            action_verb="destroy",
+            payload={
+                "target_entity_id": str(civilian_pop_center),
+                "weapon_system": "notional.indirect.medium",
+                "volume_count": 2,
+                "justification": "v1 synthetic — DoD high-stakes test",
+                "stake": "high",  # per WS-402 DestroyTool stamping
+                "target_is_civilian": True,  # exercises the civilian path
+            },
+            causal_predecessors=[],
+        ),
+    ]
+
+
+# ---- Public entry point ------------------------------------------------------
+
+
+def run_white_crew(crew_ctx: CrewContext) -> CrewResult:
+    """Execute one between-turn cycle for the white-cell adjudicator.
+
+    v1: manufactures a synthetic event batch (routine + contested +
+    high-stakes), runs adjudication, returns one Decision per event in
+    metadata. v2 integration will pull pending events from the harness
+    queue (currently empty until WS-401 grows that surface).
+    """
+    started = time.perf_counter()
+
+    # The adjudicator agent shape is constructed for parity with
+    # blue/red crews — even though v1 doesn't invoke Crew.kickoff().
+    _agent = _build_adjudicator_agent()
+
+    events = _synthetic_events(crew_ctx)
+    decisions: list[Decision] = adjudicate_events(events)
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    return CrewResult(
+        crew="white",
+        duration_ms=duration_ms,
+        notes=(
+            f"v1 deterministic white-cell adjudicator — "
+            f"{len(events)} events, "
+            f"{sum(1 for d in decisions if d.human_required)} held for human ack"
+        ),
+        metadata={
+            "tenant_id": crew_ctx.tenant_id,
+            "scenario_id": crew_ctx.scenario_id,
+            "turn": crew_ctx.turn,
+            "events_in": len(events),
+            "events_in_ids": [str(e.event_id) for e in events],
+            "decisions": [
+                {
+                    "event_id": str(d.event_id),
+                    "action_verb": d.action_verb,
+                    "source_officer_type": d.source_officer_type,
+                    "stake": d.stake,
+                    "outcome": d.outcome,
+                    "human_required": d.human_required,
+                    "contested": d.contested,
+                    "rationale": d.rationale,
+                    "conflicts_with": [str(x) for x in d.conflicts_with],
+                }
+                for d in decisions
+            ],
+        },
+    )
+
+
+# Convenience export for the eventual WS-401 integration. The harness's
+# WHITE_CREWS["default"] swap should land alongside BLUE_RUNNER +
+# RED_RUNNER once all three crews are ready to go live together.
+WHITE_RUNNER: Callable[[CrewContext], CrewResult] = run_white_crew

--- a/agents/white-cell/src/almighty_white_cell/stakes.py
+++ b/agents/white-cell/src/almighty_white_cell/stakes.py
@@ -1,0 +1,92 @@
+"""Stake classification.
+
+Per the WS-405 runbook: implement ``stake_level(event) -> 'low' |
+'medium' | 'high'`` and let callers override the heuristic for
+scenario-specific policy. The high-stakes path is the contract — the
+adjudicator holds these for human ack regardless of how the rest of
+the heuristic moves.
+
+WS-101's entity schema does not yet carry a ``population_center`` /
+``civilian`` flag (an open question I flagged in the WS-108 review).
+v1 therefore can't gate on "destroy on a population center" the way
+the runbook hints; instead we surface the runbook's intent through
+inputs the call site CAN provide:
+
+  - Verbs WS-105 marks as adjudication-flagged (`destroy` always;
+    `engage` / `disable` / `jam` optionally) escalate to high when
+    the event payload signals it (`stake='high'`, neutral target,
+    civilian-band overlap).
+  - Callers can supply a custom :class:`StakePredicate` via the
+    adjudicator constructor for scenario-specific rules (e.g., the
+    Nashville WS-601 scenario will mark certain coordinates as
+    population centers).
+
+The default predicate aims to be conservative — when in doubt,
+escalate. The white cell would rather sit through a few extra
+auto-approvable reviews than auto-commit something that should have
+been held.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Literal
+
+from almighty_kernel.dag import KernelEvent
+
+StakeLevel = Literal["low", "medium", "high"]
+StakePredicate = Callable[[KernelEvent], StakeLevel]
+
+
+# WS-105 § Summary marks these verbs as adjudication-flagged.
+_ALWAYS_HIGH_VERBS = frozenset({"destroy"})
+_OPTIONALLY_HIGH_VERBS = frozenset({"engage", "disable", "jam"})
+_MEDIUM_VERBS = frozenset({"engage", "suppress", "jam", "disable"})
+
+
+def _payload_has_high_marker(event: KernelEvent) -> bool:
+    """The WS-402 destroy tool stamps ``payload.stake = 'high'``. Other
+    tools may set this in v2. Respect the stamp regardless of verb."""
+    return event.payload.get("stake") == "high"
+
+
+def _payload_targets_neutral(event: KernelEvent) -> bool:
+    """Caller-annotated neutral target. v1 has no global entity
+    affiliation lookup, so the call site annotates the payload."""
+    return event.payload.get("target_force_affiliation") == "NEUTRAL"
+
+
+def _payload_targets_civilian(event: KernelEvent) -> bool:
+    """Caller-annotated civilian target / area / band."""
+    return bool(
+        event.payload.get("target_is_civilian")
+        or event.payload.get("civilian_band_overlap")
+        or event.payload.get("population_center", False)
+    )
+
+
+def stake_level(event: KernelEvent) -> StakeLevel:
+    """Default stake heuristic. Override by passing a custom
+    :class:`StakePredicate` to :func:`adjudicate_events`."""
+    verb = event.action_verb
+
+    # Hard-floor on the always-high verbs.
+    if verb in _ALWAYS_HIGH_VERBS:
+        return "high"
+
+    # Explicit high-stakes marker stamped by the emitter.
+    if _payload_has_high_marker(event):
+        return "high"
+
+    # Optionally-high verbs escalate when the target / area is sensitive.
+    if verb in _OPTIONALLY_HIGH_VERBS and (
+        _payload_targets_neutral(event) or _payload_targets_civilian(event)
+    ):
+        return "high"
+
+    # Effector + EW area effects without sensitive-target signals.
+    if verb in _MEDIUM_VERBS:
+        return "medium"
+
+    # Sensor reads, Mover position changes, Communicator messages,
+    # Commander orders / requests / delegations / escalations.
+    return "low"

--- a/agents/white-cell/tests/conftest.py
+++ b/agents/white-cell/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Shared fixtures."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from almighty_agent_runtime.crews import CrewContext
+from almighty_kernel.dag import KernelEvent
+
+TENANT = UUID("11111111-1111-4111-8111-111111111111")
+SCENARIO = UUID("22222222-2222-4222-8222-222222222222")
+
+
+@pytest.fixture()
+def crew_ctx() -> CrewContext:
+    return CrewContext(
+        tenant_id=str(TENANT), scenario_id=str(SCENARIO), turn=1
+    )
+
+
+def make_event(
+    *,
+    action_verb: str,
+    source_officer_type: str,
+    payload: dict | None = None,
+    turn: int = 1,
+    source_entity_id: UUID | None = None,
+) -> KernelEvent:
+    """Convenience for tests — constructs a KernelEvent in the canonical
+    test namespace."""
+    return KernelEvent(
+        event_id=uuid4(),
+        tenant_id=TENANT,
+        scenario_id=SCENARIO,
+        turn=turn,
+        source_officer_type=source_officer_type,
+        source_entity_id=source_entity_id or uuid4(),
+        action_verb=action_verb,
+        payload=payload or {},
+        causal_predecessors=[],
+    )

--- a/agents/white-cell/tests/test_adjudicator.py
+++ b/agents/white-cell/tests/test_adjudicator.py
@@ -1,0 +1,115 @@
+"""Adjudicator decision tests — covers WS-405 DoD."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from almighty_white_cell import Decision, adjudicate_events
+
+from conftest import make_event
+
+
+def test_low_stakes_event_auto_approves():
+    e = make_event(action_verb="detect", source_officer_type="SENSOR")
+    [d] = adjudicate_events([e])
+    assert isinstance(d, Decision)
+    assert d.stake == "low"
+    assert d.outcome == "auto-approve"
+    assert d.human_required is False
+
+
+def test_destroy_event_holds_for_human_ack():
+    """DoD: high-stakes path requires human ack."""
+    e = make_event(
+        action_verb="destroy",
+        source_officer_type="EFFECTOR",
+        payload={
+            "target_entity_id": str(uuid4()),
+            "weapon_system": "notional.indirect.medium",
+            "stake": "high",
+        },
+    )
+    [d] = adjudicate_events([e])
+    assert d.stake == "high"
+    assert d.outcome == "review-pending"
+    assert d.human_required is True
+    assert "human ack" in d.rationale
+
+
+def test_contested_pair_resolves_to_one_decision_each():
+    """DoD: contested-effect scenario fixture — feed blue/red event
+    pair where outcomes differ; adjudicator produces one
+    proposed_resolution per event (not one merged)."""
+    target = str(uuid4())
+    blue = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={"target_entity_id": target, "intent": "NEUTRALIZE"},
+    )
+    red = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={"target_entity_id": target, "intent": "SUPPRESS_AND_HOLD"},
+    )
+    decisions = adjudicate_events([blue, red])
+    assert len(decisions) == 2
+    for d in decisions:
+        assert d.contested is True
+        assert "contested" in d.rationale
+    # Each conflicts with the other.
+    assert decisions[0].conflicts_with == [red.event_id]
+    assert decisions[1].conflicts_with == [blue.event_id]
+
+
+def test_contested_marker_in_payload_triggers():
+    """Caller-set payload marker forces contested even without
+    target overlap."""
+    e = make_event(
+        action_verb="send",
+        source_officer_type="COMMUNICATOR",
+        payload={"contested": True},
+    )
+    [d] = adjudicate_events([e])
+    assert d.contested is True
+
+
+def test_high_stakes_AND_contested_still_holds_for_human():
+    """An event that is both high-stakes AND contested still routes to
+    review-pending (human ack), not to auto-approve."""
+    target = str(uuid4())
+    other = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={"target_entity_id": target},
+    )
+    destroy = make_event(
+        action_verb="destroy",
+        source_officer_type="EFFECTOR",
+        payload={"target_entity_id": target, "stake": "high"},
+    )
+    decisions = adjudicate_events([destroy, other])
+    destroy_decision = next(d for d in decisions if d.action_verb == "destroy")
+    assert destroy_decision.stake == "high"
+    assert destroy_decision.outcome == "review-pending"
+    assert destroy_decision.human_required is True
+    assert destroy_decision.contested is True
+    assert "contested" in destroy_decision.rationale
+
+
+def test_custom_stake_predicate_overrides_default():
+    """Caller-supplied predicate is honored for scenario-specific policy."""
+    e = make_event(action_verb="send", source_officer_type="COMMUNICATOR")
+    decisions = adjudicate_events(
+        [e],
+        stake_predicate=lambda _e: "high",
+    )
+    assert decisions[0].stake == "high"
+    assert decisions[0].human_required is True
+
+
+def test_decision_order_matches_event_order():
+    a = make_event(action_verb="detect", source_officer_type="SENSOR")
+    b = make_event(action_verb="move_to", source_officer_type="MOVER")
+    c = make_event(action_verb="send", source_officer_type="COMMUNICATOR")
+    decisions = adjudicate_events([a, b, c])
+    assert [d.event_id for d in decisions] == [a.event_id, b.event_id, c.event_id]

--- a/agents/white-cell/tests/test_crew.py
+++ b/agents/white-cell/tests/test_crew.py
@@ -1,0 +1,79 @@
+"""End-to-end tests for the white-cell crew runner."""
+
+from __future__ import annotations
+
+from almighty_white_cell import run_white_crew
+
+
+def test_crew_runs_and_returns_per_event_decisions(crew_ctx):
+    result = run_white_crew(crew_ctx)
+    assert result.crew == "white"
+    # Synthetic event batch is 6 events (3 routine + 2 contested + 1 destroy).
+    assert result.metadata["events_in"] == 6
+    assert len(result.metadata["decisions"]) == 6
+    assert result.duration_ms >= 0
+    assert result.metadata["tenant_id"] == crew_ctx.tenant_id
+    assert result.metadata["scenario_id"] == crew_ctx.scenario_id
+    assert result.metadata["turn"] == crew_ctx.turn
+
+
+def test_crew_holds_destroy_for_human_ack(crew_ctx):
+    """DoD: synthetic destroy event → human_required=true; gateway
+    state confirmed held (we assert outcome='review-pending' as the
+    gateway-state proxy)."""
+    result = run_white_crew(crew_ctx)
+    destroy_decisions = [
+        d for d in result.metadata["decisions"] if d["action_verb"] == "destroy"
+    ]
+    assert len(destroy_decisions) == 1
+    d = destroy_decisions[0]
+    assert d["stake"] == "high"
+    assert d["outcome"] == "review-pending"
+    assert d["human_required"] is True
+
+
+def test_crew_resolves_contested_pair(crew_ctx):
+    """DoD: contested-effect scenario — both engage events on the
+    shared target are flagged contested with mutual conflicts_with
+    references."""
+    result = run_white_crew(crew_ctx)
+    engage_decisions = [
+        d for d in result.metadata["decisions"] if d["action_verb"] == "engage"
+    ]
+    assert len(engage_decisions) == 2
+    for d in engage_decisions:
+        assert d["contested"] is True
+        assert len(d["conflicts_with"]) == 1
+    assert engage_decisions[0]["conflicts_with"] == [engage_decisions[1]["event_id"]]
+    assert engage_decisions[1]["conflicts_with"] == [engage_decisions[0]["event_id"]]
+
+
+def test_crew_auto_approves_routine_events(crew_ctx):
+    """The 3 routine events (detect / move_to / send) auto-approve."""
+    result = run_white_crew(crew_ctx)
+    routine = [
+        d
+        for d in result.metadata["decisions"]
+        if d["action_verb"] in ("detect", "move_to", "send")
+    ]
+    assert len(routine) == 3
+    for d in routine:
+        assert d["stake"] == "low"
+        assert d["outcome"] == "auto-approve"
+        assert d["human_required"] is False
+
+
+def test_crew_notes_summary_string(crew_ctx):
+    """The notes string reports the held-for-human count."""
+    result = run_white_crew(crew_ctx)
+    held = sum(1 for d in result.metadata["decisions"] if d["human_required"])
+    assert held >= 1
+    assert f"{held} held for human ack" in result.notes
+
+
+def test_runner_export_is_callable(crew_ctx):
+    from almighty_white_cell import WHITE_RUNNER
+
+    out = WHITE_RUNNER(crew_ctx)
+    assert out.crew == "white"
+    assert out.metadata["events_in"] == 6

--- a/agents/white-cell/tests/test_stakes.py
+++ b/agents/white-cell/tests/test_stakes.py
@@ -1,0 +1,101 @@
+"""Stake classification tests."""
+
+from __future__ import annotations
+
+from almighty_white_cell import stake_level
+
+from conftest import make_event
+
+
+def test_destroy_is_always_high():
+    e = make_event(
+        action_verb="destroy",
+        source_officer_type="EFFECTOR",
+        payload={"target_entity_id": "00000000-0000-4000-8000-000000000000"},
+    )
+    assert stake_level(e) == "high"
+
+
+def test_explicit_stake_marker_escalates():
+    """Even a non-destroy verb escalates when payload.stake='high' is
+    stamped (e.g., by a v2 tool)."""
+    e = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={"stake": "high"},
+    )
+    assert stake_level(e) == "high"
+
+
+def test_engage_against_neutral_is_high():
+    e = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={"target_force_affiliation": "NEUTRAL"},
+    )
+    assert stake_level(e) == "high"
+
+
+def test_disable_against_civilian_is_high():
+    e = make_event(
+        action_verb="disable",
+        source_officer_type="EFFECTOR",
+        payload={"target_is_civilian": True, "method": "KINETIC"},
+    )
+    assert stake_level(e) == "high"
+
+
+def test_jam_with_civilian_band_overlap_is_high():
+    e = make_event(
+        action_verb="jam",
+        source_officer_type="COMMUNICATOR",
+        payload={"civilian_band_overlap": True, "band": "VHF"},
+    )
+    assert stake_level(e) == "high"
+
+
+def test_engage_routine_is_medium():
+    e = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={"weapon_system": "notional.indirect.medium"},
+    )
+    assert stake_level(e) == "medium"
+
+
+def test_suppress_is_medium():
+    e = make_event(action_verb="suppress", source_officer_type="EFFECTOR")
+    assert stake_level(e) == "medium"
+
+
+def test_jam_routine_is_medium():
+    e = make_event(
+        action_verb="jam",
+        source_officer_type="COMMUNICATOR",
+        payload={"band": "L"},
+    )
+    assert stake_level(e) == "medium"
+
+
+def test_detect_is_low():
+    e = make_event(
+        action_verb="detect",
+        source_officer_type="SENSOR",
+        payload={"modality": "RADAR"},
+    )
+    assert stake_level(e) == "low"
+
+
+def test_move_to_is_low():
+    e = make_event(action_verb="move_to", source_officer_type="MOVER")
+    assert stake_level(e) == "low"
+
+
+def test_send_is_low():
+    e = make_event(action_verb="send", source_officer_type="COMMUNICATOR")
+    assert stake_level(e) == "low"
+
+
+def test_issue_order_is_low():
+    e = make_event(action_verb="issue_order", source_officer_type="COMMANDER")
+    assert stake_level(e) == "low"


### PR DESCRIPTION
## Summary

Single agent that runs after blue and red crews complete. Reads the turn's pending events, classifies each by stake, and proposes a resolution that the WS-303 override gateway either commits (low/medium) or **holds for human ack (high)**.

Closes #25.

## Stake heuristic (override via `stake_predicate` kwarg)

| Stake | Trigger |
|---|---|
| **high** | `destroy` verb (always); `payload.stake='high'` marker; `engage`/`disable`/`jam` against `target_force_affiliation='NEUTRAL'`, `target_is_civilian=True`, `population_center=True`, or `civilian_band_overlap=True`. |
| **medium** | `engage` / `suppress` / `jam` / `disable` without sensitive-target signals. |
| **low** | Sensor reads, Mover position changes, Communicator messages, Commander orders. |

The high-stakes path is the **contract**: a destroy event that's also contested still routes to `review-pending` (asserted in `test_high_stakes_AND_contested_still_holds_for_human`).

> **Why not "destroy on a population center"?** WS-101's entity schema lacks the `population_center` flag (Open Q from my WS-108 review). v1 surfaces the runbook's intent through caller-annotated payload fields. Scenario-specific predicates can supply richer logic — WS-601 (Nashville) will likely consult a named-area-of-interest map.

## Contested-effect detection (override via `contested_predicate` kwarg)

Default flags an event as contested when:
1. `payload.contested = True` marker, OR
2. `payload.adjudication_state == 'contested'` (per WS-108 § 2 enum), OR
3. Another event in the same batch targets the same `target_entity_id` in the same turn.

(3) catches "did the EW cone actually degrade comms?" — overlapping claims on the same target entity. Adjudicator emits **one Decision per event** (not one merged); each contested event names its conflicts via `conflicts_with`.

## Decision shape

Mirrors WS-303 `override_decisions` audit row:

```python
@dataclass(frozen=True)
class Decision:
    event_id: UUID
    action_verb: str
    source_officer_type: str
    stake: Literal["low", "medium", "high"]
    outcome: Literal["auto-approve", "review-pending"]
    human_required: bool
    contested: bool
    rationale: str
    conflicts_with: list[UUID]
```

## Layout

```
agents/white-cell/
├── pyproject.toml
├── README.md
├── src/almighty_white_cell/
│   ├── stakes.py         stake_level() + StakePredicate type
│   ├── adjudicator.py    Decision + adjudicate_events(events, *, stake_predicate, contested_predicate)
│   └── crew.py           run_white_crew(ctx), WHITE_RUNNER, synthetic 6-event batch
└── tests/                25 passing
```

## Tests — 25 passing

```
$ pytest -v
tests/test_adjudicator.py .......                                        [ 28%]
tests/test_crew.py ......                                                [ 52%]
tests/test_stakes.py ............                                        [100%]
25 passed in 0.64s
```

- **`test_stakes.py`** (12): every verb + every sensitive-target signal — destroy always high, payload markers, neutral / civilian / civilian-band overlap, medium/low defaults.
- **`test_adjudicator.py`** (7): low auto-approves; high holds for human; contested pair → two Decisions with mutual `conflicts_with`; high-stakes-AND-contested still holds; custom predicate honored; decision order matches event order.
- **`test_crew.py`** (6): end-to-end via `run_white_crew(ctx)` against the synthetic 6-event batch — confirms both DoD scenarios (contested-pair + high-stakes destroy held for human ack), routine events auto-approve, runner export callable.

Real `KernelEvent` instances throughout — no mocks of upstream contracts.

## Definition of done check

- [x] All criteria from #25 satisfied: adjudicator handles a contested-effect test scenario; high-stakes path requires human ack.
- [x] Documentation updated — README has the stake heuristic table, contested predicate, decision shape, integration notes for WS-303 and WS-401.
- [x] Tests added or updated — 25 passing.
- [x] Banner present on any new visual surface — N/A (Python library).

## Decisions worth flagging

1. **Single agent, not a six-role staff.** White cell is structurally different from blue/red. The adjudicator's tool-set is empty — it doesn't issue officer verbs, it reads them.
2. **Decisions returned, not POSTed.** v1 doesn't HTTP-POST to Alex's control-plane WS-303 service; the adjudicator returns a `list[Decision]` and lets the caller wire them. Same scope-discipline as WS-403/404 → WS-401 harness. Wiring is a follow-up integration ticket.
3. **Synthetic event batch, not harness-queue pull.** The v1 `run_white_crew` manufactures 6 events (3 routine + 2 contested-pair + 1 high-stakes destroy) so the harness can exercise both DoD scenarios without depending on a queue surface that WS-401 doesn't expose yet.
4. **Stake predicate is a contract, not a default.** Custom predicates may broaden `high` but should never downgrade an obviously-high event without a clear scenario reason. Adjudicator doctrine: "would rather sit through a few extra auto-approvable reviews than auto-commit something that should have been held."
5. **WHITE_RUNNER matches CrewRunner signature** for the eventual WS-401 swap once all three crews land together.

## Downstream impact

- **Phase 4 done after this lands.** ✅ WS-401 (Shane) ✅ WS-402 (you) ✅ WS-403 (you) ✅ WS-404 (you) → WS-405 (you, this PR).
- **Integration ticket** to file once this merges: register `BLUE_RUNNER` / `RED_RUNNER` / `WHITE_RUNNER` in `agents/runtime/src/almighty_agent_runtime/crews.py`. The harness will run blue → red → white via Celery chain; the white runner consumes the union of blue + red commits per turn.
- **WS-303 wiring** is a separate follow-up: the adjudicator's `Decision` list needs to be POSTed to `/tenants/:id/scenarios/:sid/events/:eid/decision` for `review-pending` outcomes, and the `auto-approve` outcomes can short-circuit through the gateway's existing `evaluateEvent` path.
- **WS-505** (white-cell console, already merged) is the human-side counterpart: operators see `review-pending` events queued by this adjudicator and approve / block via the manual-decision endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)