### PR TITLE
WS-503 — Live PyRapide → CZML adapter (kernel side)

### DIFF
--- a/services/czml-adapter/README.md
+++ b/services/czml-adapter/README.md
@@ -1,0 +1,258 @@
+# `almighty-czml-adapter` — WS-503 (kernel side)
+
+> **Classification:** UNCLASSIFIED — FOR DEMONSTRATION PURPOSES ONLY
+
+Live PyRapide → CZML adapter. Subscribes to a tenant's `events` channel
+on the WS-304 fan-out service, translates each spatial-artifact-bearing
+event into a post-substitution CZML packet (gated by the WS-202
+validator), and publishes the packet to the tenant's `czml_packets`
+channel.
+
+**Joint ownership** with WS-503 renderer side (Alex). This package is
+the kernel-side adapter; the renderer-side React + Resium component
+that consumes `czml_packets` is owned by Alex. See
+[§ Renderer-side integration contract](#renderer-side-integration-contract-for-alex)
+below for the wire shape.
+
+## Pipeline
+
+```
+            ┌─────────────────┐
+            │  WS-304 events  │   (tenant-scoped fan-out subscription)
+            │     channel     │
+            └─────────┬───────┘
+                      │
+                      ▼
+        ┌──────────────────────────────┐
+        │   AdapterRunner.run()        │
+        │                              │
+        │   for event in stream:       │
+        │     result = translate_event │
+        │     if ACCEPTED -> publish   │ ─────► HTTP POST /publish
+        │     if REJECTED -> publish   │       channel=czml_packets
+        │       on czml_rejected       │       payload={CZML packet}
+        │     if SKIPPED  -> ignore    │
+        └──────────────────────────────┘
+```
+
+The translator is pure (no I/O); the runner glues it to the WS-304
+service. Tests run the translator in-process and the runner against
+stub stream / sink — no live WS or HTTP needed.
+
+## Family coverage (v1: 7 of 9)
+
+| Family | Trigger | Validator gate |
+|---|---|---|
+| `jamming_circle` | `Communicator.jam` OR `Effector.disable(method=EW)` | `radius_m`, `power_w` |
+| `indirect_fire_arc` | `Effector.engage`/`suppress`/`destroy` OR `Effector.disable(method=KINETIC)` | `range_m`, `time_of_flight_s`, `dispersion_ellipse_a_m`, `dispersion_ellipse_b_m` |
+| `radar_fan` | `Sensor.detect`/`track` with `modality=RADAR` | `azimuth_deg`, `sweep_arc_deg`, `range_m` |
+| `ew_cone` | `Sensor.detect` with `modality=RF` | `azimuth_deg`, `beamwidth_deg`, `effective_range_m` |
+| `masint_cell` | `Sensor.detect`/`classify` with `modality ∈ {ACOUSTIC, SEISMIC, MASINT_MULTI}` | `polygon_area_m2`, `dwell_s` |
+| `keyhole_footprint` | `Sensor.classify` (non-MASINT modality) | `polygon_area_m2` |
+| `uas_corridor` | `Communicator.relay` with `payload.is_airborne=True` | `altitude_band_lower_m`, `altitude_band_upper_m`, `width_m` |
+
+Per the runbook + WS-108 § 6 verb-emission table.
+
+**Deferred to v2:**
+
+- **`ir_plume`** — needs kernel-side follow-on event emission from `Effector.destroy`. The kernel doesn't emit follow-on events yet, so v1's destroy events produce only `indirect_fire_arc`.
+- **`satellite_swath`** — needs SPACE_UNIT entity-type signal that the adapter doesn't currently get from the events stream. Requires either an `entity_type` field on the event payload or an entity-table lookup.
+
+## Result semantics
+
+Every event yields one `AdapterResult`:
+
+```python
+@dataclass
+class AdapterResult:
+    kind: ResultKind   # ACCEPTED | REJECTED | SKIPPED
+    event_id: UUID
+    family: str | None
+    packet: dict[str, Any] | None     # set on ACCEPTED
+    reason: str | None                # set on REJECTED / SKIPPED
+    validator_params: dict[str, Any]  # set on ACCEPTED / REJECTED
+```
+
+- **ACCEPTED** — `packet` ready to publish on `czml_packets`.
+- **REJECTED** — validator rejected; runner emits a `czml_rejected` audit on a virtual channel of the same name (so AAR can replay rejections per WS-108 § 7.4).
+- **SKIPPED** — non-spatial verb (Mover / Commander / Communicator non-spatial) OR `EO_IR` detect (no template in v1). No packet, no audit.
+
+## Renderer-side integration contract (for Alex)
+
+The renderer-side component (replacing WS-502's static-only loader)
+consumes `czml_packets` over the WS-304 channel.
+
+### Subscribe
+
+Per [services/websocket/README.md](../websocket/README.md):
+
+```js
+const ws = new WebSocket(`wss://host:port/ws?token=${jwt}`);
+ws.onopen = () => ws.send(JSON.stringify({
+  action: "subscribe",
+  channel: "czml_packets",
+}));
+ws.onmessage = (msg) => {
+  const env = JSON.parse(msg.data);
+  if (env.type !== "message" || env.channel !== "czml_packets") return;
+  // env.tenant_id, env.payload (a CZML packet)
+  applyPacket(env.payload);
+};
+```
+
+### Packet shape
+
+Each `payload` is a single Cesium CZML packet — exactly the post-substituted
+`base` block from the corresponding WS-201 template. For example, a
+`jamming_circle`:
+
+```json
+{
+  "id": "<artifact-uuid>",
+  "name": "Jamming circle — <owning-entity-uuid>",
+  "description": "Jamming circle, radius 2000.0 m, power 500.0 W, band L",
+  "availability": "2026-04-25T18:00:00+00:00/2026-04-25T18:01:30+00:00",
+  "position": { "cartographicDegrees": [-86.79, 36.175, 170.0] },
+  "ellipse": {
+    "semiMajorAxis": 2000.0,
+    "semiMinorAxis": 2000.0,
+    "material": { "solidColor": { "color": { "rgba": [255, 80, 60, 90] } } },
+    "outline": true,
+    "outlineColor": { "rgba": [255, 80, 60, 220] },
+    "heightReference": "CLAMP_TO_GROUND"
+  }
+}
+```
+
+The adapter substitutes every `{{token}}` placeholder. Renderer can
+hand the packet straight to a Resium `<CzmlDataSource>` incremental
+load (no further parsing). One packet ≈ one feature on the map; the
+`id` is the artifact UUID and is stable across re-publishes.
+
+### Live/static toggle
+
+Replace WS-502's static-only loader with a toggle:
+
+- **Static mode** — load a `.czml` file directly (current WS-502 behavior).
+- **Live mode** — open the WS-304 subscription above, accumulate packets into a `<CzmlDataSource>` instance, and let Resium re-render incrementally as packets arrive.
+
+### Deletion (v2)
+
+Per the runbook, the adapter should publish CZML packets with `delete: true` when an effect ends. v1 does NOT do this — the templates carry `availability` time windows and the renderer can rely on Cesium's own time-based hide / show. v2 will add explicit deletion publishing when the kernel grows artifact-end events.
+
+### Capability gating signal (renderer doesn't need to do anything)
+
+The DoD requires "rejected packets do not render." That holds because rejected events never get published — the validator gates on the adapter side. The renderer doesn't see them. AAR replay (WS-506) reads the `czml_rejected` audit channel separately for post-mortem rendering of what was blocked.
+
+## Stack
+
+- Python ≥ 3.11
+- `fastapi` for the `/healthz` shell
+- `httpx` (async) for `POST /publish`
+- `websockets` for the `events` subscription
+- `pydantic` 2.6+
+- Editable deps on `almighty-kernel` (KernelEvent shape) and `almighty-czml-validator` (in-process validator + template loader)
+
+## Run
+
+```bash
+# From this directory:
+python3.13 -m venv .venv
+source .venv/bin/activate
+pip install -e ../../kernel
+pip install -e ../czml-validator
+pip install -e ".[test]"
+
+# Run the test suite
+pytest -v
+
+# Run the FastAPI shell (healthz only — no auto-start of the runner)
+uvicorn almighty_czml_adapter.app:app --reload --port 8012
+```
+
+To start the runner against a real WS-304 service, wire it manually:
+
+```python
+import asyncio
+from almighty_czml_validator import Validator
+from almighty_czml_validator.templates import TemplateLoader
+from almighty_czml_adapter.runner import AdapterRunner, HttpPacketSink, WsEventStream
+
+async def main():
+    template_loader = TemplateLoader()
+    validator = Validator(template_loader=template_loader)
+    stream = WsEventStream(ws_url="ws://websocket:4001/ws", jwt=os.environ["ADAPTER_JWT"])
+    async with HttpPacketSink(
+        publish_url="http://websocket:4001/publish",
+        jwt=os.environ["ADAPTER_JWT"],
+    ) as sink:
+        runner = AdapterRunner(
+            stream=stream,
+            sink=sink,
+            validator=validator,
+            template_loader=template_loader,
+            capability_profile=load_profile_for_tenant(),  # caller wires this
+        )
+        await runner.run()
+
+asyncio.run(main())
+```
+
+The adapter JWT must carry `cell_role: 'white'` because WS-304's `/publish` endpoint requires it.
+
+## Tests — 24 passing
+
+```
+$ pytest -v
+tests/test_app.py .                                                      [  4%]
+tests/test_runner.py ..                                                  [ 12%]
+tests/test_translator.py .....................                           [100%]
+24 passed in 0.08s
+```
+
+- **7 family happy-paths** — one per v1 family, asserting `kind == ACCEPTED` and the substituted packet shape (whole-value tokens become native types; interpolated tokens fill into description / name strings).
+- **3 reject paths** — jam over peer's power_w cap; us-bct lacks `jam` (validator's verb gate fires); engage over us-bct's range_m cap. Confirms capability-gating is exercised end-to-end.
+- **9 skip paths** — 8 non-spatial verbs (Mover, Commander, Communicator non-spatial) + `EO_IR` detect.
+- **2 token-substitution sanity** — packet.id is the synthesized artifact UUID (not literal `{{artifact_id}}`); validator_params reflected on result for AAR audit.
+- **2 runner integration tests** — `_StreamFromList` + `_CollectingSink` stubs; verifies accepted → publish path, rejected → publish_rejected path, skipped → silently dropped, empty stream is a no-op.
+- **1 HTTP smoke** — `/healthz` returns `{status: ok}`.
+
+Real `KernelEvent`, real `Validator`, real `TemplateLoader`, real WS-107 profiles loaded from disk. No mocks of upstream contracts.
+
+## Layout
+
+```
+services/czml-adapter/
+├── pyproject.toml
+├── README.md                                       ← this file
+├── src/almighty_czml_adapter/
+│   ├── __init__.py                                 ← exports translate_event, AdapterResult, EntityPosition
+│   ├── models.py                                   ← AdapterResult tagged union, ResultKind, EntityPosition
+│   ├── families.py                                 ← per-family detector + token builder + validator-param keys
+│   ├── translator.py                               ← translate_event (pure, no I/O)
+│   ├── runner.py                                   ← AdapterRunner + WsEventStream + HttpPacketSink
+│   └── app.py                                      ← FastAPI: /healthz only
+└── tests/
+    ├── conftest.py                                 ← real upstream fixtures
+    ├── test_translator.py                          ← family happy + reject + skip
+    ├── test_runner.py                              ← runner glue with stub stream/sink
+    └── test_app.py                                 ← /healthz
+```
+
+## Notes / open questions
+
+- **Entity-position lookup is caller-supplied.** v1's default callback returns a Nashville-anchored point so demos render somewhere visible. Production callers MUST supply a real lookup that reads from the entities table — that's a v2 integration when this adapter is wired into the running stack.
+- **Capability-profile-per-tenant** is a single dict in v1. A real deployment will want a `lookup_profile_for(tenant_id, agent_entity_id)` callback. Same v2 wiring as the entity lookup.
+- **No `ir_plume` or `satellite_swath`.** Documented above — both need upstream changes (follow-on event emission and entity-type signal respectively).
+- **No deletion publishing yet.** Templates' `availability` windows handle most cases; explicit `delete: true` publishing is a v2 candidate.
+- **Adapter does NOT post to WS-303.** Rejection audit is sent on the `czml_rejected` virtual channel. WS-506 (AAR) consumes it. v2 may also wire to WS-303's `override_decisions` table for full audit-trail consolidation.
+
+## See also
+
+- [`docs/schema/officer-interfaces.md`](../../docs/schema/officer-interfaces.md) — verb signatures (WS-105).
+- [`docs/schema/artifacts.md`](../../docs/schema/artifacts.md) — verb→artifact mapping (WS-108).
+- [`czml/templates/README.md`](../../czml/templates/README.md) — template format + token substitution rules (WS-201).
+- [`services/czml-validator/`](../czml-validator/) — in-process validator (WS-202).
+- [`services/websocket/`](../websocket/) — fan-out service this adapter subscribes / publishes to (WS-304).
+- WS-503 renderer side (Alex) — the React + Resium component that consumes `czml_packets`.
+- WS-506 (#31) — AAR replay; consumes `czml_rejected` audit channel.

--- a/services/czml-adapter/pyproject.toml
+++ b/services/czml-adapter/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "almighty-czml-adapter"
+version = "0.1.0"
+description = "Live PyRapide → CZML adapter service for Almighty (WS-503)"
+requires-python = ">=3.11"
+authors = [{ name = "Dynamo Technologies" }]
+dependencies = [
+    "fastapi>=0.115",
+    "pydantic>=2.7",
+    "uvicorn[standard]>=0.30",
+    "httpx>=0.27",
+    "websockets>=13.0",
+    "almighty-kernel",
+    "almighty-czml-validator",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
+asyncio_mode = "auto"

--- a/services/czml-adapter/src/almighty_czml_adapter/__init__.py
+++ b/services/czml-adapter/src/almighty_czml_adapter/__init__.py
@@ -1,0 +1,20 @@
+"""Almighty live PyRapide -> CZML adapter (WS-503).
+
+Subscribes to a tenant's `events` channel on the WS-304 fan-out
+service, translates each spatial-artifact-bearing event into a
+post-substitution CZML packet (gated by the WS-202 validator), and
+publishes the packet to the tenant's `czml_packets` channel for the
+Resium renderer (WS-503 renderer side, owned by Alex).
+
+See README.md for the renderer-side integration contract.
+"""
+
+from .models import AdapterResult, EntityPosition, ResultKind
+from .translator import translate_event
+
+__all__ = [
+    "AdapterResult",
+    "EntityPosition",
+    "ResultKind",
+    "translate_event",
+]

--- a/services/czml-adapter/src/almighty_czml_adapter/app.py
+++ b/services/czml-adapter/src/almighty_czml_adapter/app.py
@@ -1,0 +1,21 @@
+"""FastAPI shell — exposes only ``/healthz`` for liveness probes.
+
+The adapter's actual work runs in the async ``AdapterRunner`` (see
+runner.py); the FastAPI app exists so the service can be deployed
+behind a standard HTTP probe and admin tooling can introspect.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+app = FastAPI(
+    title="Almighty CZML adapter",
+    version="0.1.0",
+    description="Live PyRapide -> CZML adapter (WS-503).",
+)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok"}

--- a/services/czml-adapter/src/almighty_czml_adapter/families.py
+++ b/services/czml-adapter/src/almighty_czml_adapter/families.py
@@ -1,0 +1,361 @@
+"""Per-family translators.
+
+Each family has:
+
+  detector(event)        -> bool : does this event produce this family?
+  token_builder(event,
+                position,
+                artifact_id) -> dict : full token map for the template
+                                       substitution + validator params.
+  validator_param_keys   : list[str] : subset of tokens passed to the
+                                       validator's `params` dict.
+
+The translator iterates families in priority order (per WS-108 § 6
+emission rules) and dispatches on the first match. Caller-supplied
+``entity_position_lookup`` provides emitter-anchored coordinates for
+shapes that need them (jamming circle origin, EW cone apex, etc.).
+
+v1 family coverage (7 of 9):
+
+  jamming_circle, indirect_fire_arc, radar_fan, ew_cone, masint_cell,
+  keyhole_footprint, uas_corridor
+
+Deferred to v2:
+
+  - ir_plume     — needs kernel-side follow-on event emission from
+                   `Effector.destroy` (no machinery yet).
+  - satellite_swath — needs SPACE_UNIT entity-type signal that the
+                   adapter doesn't currently get from events.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+from uuid import UUID, uuid4
+
+from almighty_kernel.dag import KernelEvent
+
+from .models import EntityPosition
+
+TokenBuilder = Callable[[KernelEvent, EntityPosition, UUID], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class FamilyHandler:
+    family: str  # underscored: jamming_circle
+    template_id: str  # hyphenated: jamming-circle
+    detector: Callable[[KernelEvent], bool]
+    token_builder: TokenBuilder
+    validator_param_keys: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Detectors
+# ---------------------------------------------------------------------------
+
+
+def _detect_jamming_circle(e: KernelEvent) -> bool:
+    if e.action_verb == "jam":
+        return True
+    if e.action_verb == "disable" and e.payload.get("method") == "EW":
+        return True
+    return False
+
+
+def _detect_indirect_fire_arc(e: KernelEvent) -> bool:
+    if e.action_verb in ("engage", "suppress", "destroy"):
+        return True
+    if e.action_verb == "disable" and e.payload.get("method") == "KINETIC":
+        return True
+    return False
+
+
+def _detect_radar_fan(e: KernelEvent) -> bool:
+    return (
+        e.action_verb in ("detect", "track")
+        and e.payload.get("modality") == "RADAR"
+    )
+
+
+def _detect_ew_cone(e: KernelEvent) -> bool:
+    return e.action_verb == "detect" and e.payload.get("modality") == "RF"
+
+
+def _detect_masint_cell(e: KernelEvent) -> bool:
+    if e.action_verb in ("detect", "classify") and e.payload.get("modality") in (
+        "ACOUSTIC",
+        "SEISMIC",
+        "MASINT_MULTI",
+    ):
+        return True
+    return False
+
+
+def _detect_keyhole_footprint(e: KernelEvent) -> bool:
+    return e.action_verb == "classify" and e.payload.get("modality") not in (
+        "ACOUSTIC",
+        "SEISMIC",
+        "MASINT_MULTI",
+    )
+
+
+def _detect_uas_corridor(e: KernelEvent) -> bool:
+    return (
+        e.action_verb == "relay"
+        and bool(e.payload.get("is_airborne"))
+        # advertise_corridor is a profile flag the WS-402 RelayTool
+        # already enforced — by the time we see the event, presence of
+        # is_airborne=True is the signal.
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token builders
+#
+# Common tokens (id, name, time validity) are stamped by every builder.
+# Per-family tokens come straight from the event payload.
+# ---------------------------------------------------------------------------
+
+
+def _common_tokens(
+    event: KernelEvent,
+    artifact_id: UUID,
+    *,
+    duration_s: float = 60.0,
+) -> dict[str, Any]:
+    return {
+        "artifact_id": str(artifact_id),
+        "owning_entity_id": str(event.source_entity_id),
+        "time_validity_start": event.ts.isoformat(),
+        "time_validity_end": _shift_iso(event.ts.isoformat(), duration_s),
+    }
+
+
+def _shift_iso(iso: str, seconds: float) -> str:
+    """Shift an ISO-8601 timestamp by N seconds. Naive — uses datetime
+    parser; v1 duration math is per-event-per-family."""
+    from datetime import datetime, timedelta, timezone
+
+    dt = datetime.fromisoformat(iso)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (dt + timedelta(seconds=seconds)).isoformat()
+
+
+# Default colors per family (CZML rgba). Templates also have defaults;
+# we substitute matching ones so the packet is fully determined.
+_RED_FILL = [255, 80, 60, 90]
+_RED_OUTLINE = [255, 80, 60, 220]
+_BLUE_FILL = [60, 140, 255, 90]
+_BLUE_OUTLINE = [60, 140, 255, 220]
+_AMBER_FILL = [255, 200, 60, 90]
+_AMBER_OUTLINE = [255, 200, 60, 220]
+
+
+def _build_jamming_circle(
+    event: KernelEvent, position: EntityPosition, artifact_id: UUID
+) -> dict[str, Any]:
+    payload = event.payload
+    duration = float(payload.get("duration_s", 60.0))
+    return {
+        **_common_tokens(event, artifact_id, duration_s=duration),
+        "origin_lat_deg": position.lat_deg,
+        "origin_lon_deg": position.lon_deg,
+        "origin_alt_m": position.alt_m,
+        "radius_m": float(payload["radius_m"]),
+        "power_w": float(payload["power_w"]),
+        "band": str(payload.get("band", "VHF")),
+        "fill_rgba": _RED_FILL,
+        "outline_rgba": _RED_OUTLINE,
+    }
+
+
+def _build_indirect_fire_arc(
+    event: KernelEvent, position: EntityPosition, artifact_id: UUID
+) -> dict[str, Any]:
+    payload = event.payload
+    target = payload.get("target_coordinate") or {}
+    impact_lat = float(target.get("lat_deg", position.lat_deg))
+    impact_lon = float(target.get("lon_deg", position.lon_deg))
+    impact_alt = float(target.get("alt_m", position.alt_m))
+    tof = float(payload.get("time_of_flight_s", 0.0))
+    return {
+        **_common_tokens(event, artifact_id, duration_s=tof + 30.0),
+        "firing_lat_deg": position.lat_deg,
+        "firing_lon_deg": position.lon_deg,
+        "firing_alt_m": position.alt_m,
+        "impact_lat_deg": impact_lat,
+        "impact_lon_deg": impact_lon,
+        "impact_alt_m": impact_alt,
+        "range_m": float(payload["range_m"]),
+        "time_of_flight_s": tof,
+        "dispersion_ellipse_a_m": float(payload.get("dispersion_ellipse_a_m", 50.0)),
+        "dispersion_ellipse_b_m": float(payload.get("dispersion_ellipse_b_m", 50.0)),
+        "mode": event.action_verb,  # engage / suppress / destroy / disable
+        "volume_count": int(payload.get("volume_count", 1)),
+        "fill_rgba": _RED_FILL,
+        "outline_rgba": _RED_OUTLINE,
+    }
+
+
+def _build_radar_fan(
+    event: KernelEvent, position: EntityPosition, artifact_id: UUID
+) -> dict[str, Any]:
+    payload = event.payload
+    return {
+        **_common_tokens(event, artifact_id, duration_s=120.0),
+        "origin_lat_deg": position.lat_deg,
+        "origin_lon_deg": position.lon_deg,
+        "origin_alt_m": position.alt_m,
+        "azimuth_deg": float(payload.get("azimuth_deg", 0.0)),
+        "sweep_arc_deg": float(payload.get("sweep_arc_deg", 60.0)),
+        "range_m": float(payload["range_m"]),
+        "elevation_deg": float(payload.get("elevation_deg", 0.0)),
+        "fill_rgba": _BLUE_FILL,
+        "outline_rgba": _BLUE_OUTLINE,
+    }
+
+
+def _build_ew_cone(
+    event: KernelEvent, position: EntityPosition, artifact_id: UUID
+) -> dict[str, Any]:
+    payload = event.payload
+    return {
+        **_common_tokens(event, artifact_id, duration_s=60.0),
+        "origin_lat_deg": position.lat_deg,
+        "origin_lon_deg": position.lon_deg,
+        "origin_alt_m": position.alt_m,
+        "azimuth_deg": float(payload.get("azimuth_deg", 0.0)),
+        "beamwidth_deg": float(payload.get("beamwidth_deg", 30.0)),
+        "effective_range_m": float(payload["range_m"]),
+        "band": str(payload.get("band", "RF")),
+        "fill_rgba": _BLUE_FILL,
+        "outline_rgba": _BLUE_OUTLINE,
+    }
+
+
+def _build_masint_cell(
+    event: KernelEvent, position: EntityPosition, artifact_id: UUID
+) -> dict[str, Any]:
+    payload = event.payload
+    polygon_area = float(payload.get("polygon_area_m2", 50_000.0))
+    return {
+        **_common_tokens(event, artifact_id, duration_s=600.0),
+        "origin_lat_deg": position.lat_deg,
+        "origin_lon_deg": position.lon_deg,
+        "origin_alt_m": position.alt_m,
+        "polygon_area_m2": polygon_area,
+        "dwell_s": float(payload.get("dwell_s", 600.0)),
+        "fill_rgba": _AMBER_FILL,
+        "outline_rgba": _AMBER_OUTLINE,
+    }
+
+
+def _build_keyhole_footprint(
+    event: KernelEvent, position: EntityPosition, artifact_id: UUID
+) -> dict[str, Any]:
+    payload = event.payload
+    polygon_area = float(payload.get("polygon_area_m2", 25_000.0))
+    return {
+        **_common_tokens(event, artifact_id, duration_s=300.0),
+        "origin_lat_deg": position.lat_deg,
+        "origin_lon_deg": position.lon_deg,
+        "origin_alt_m": position.alt_m,
+        "polygon_area_m2": polygon_area,
+        "fill_rgba": _BLUE_FILL,
+        "outline_rgba": _BLUE_OUTLINE,
+    }
+
+
+def _build_uas_corridor(
+    event: KernelEvent, position: EntityPosition, artifact_id: UUID
+) -> dict[str, Any]:
+    payload = event.payload
+    return {
+        **_common_tokens(event, artifact_id, duration_s=300.0),
+        "origin_lat_deg": position.lat_deg,
+        "origin_lon_deg": position.lon_deg,
+        "origin_alt_m": position.alt_m,
+        "altitude_band_lower_m": float(payload.get("altitude_band_lower_m", 500.0)),
+        "altitude_band_upper_m": float(payload.get("altitude_band_upper_m", 2_000.0)),
+        "width_m": float(payload.get("width_m", 2_000.0)),
+        "fill_rgba": _BLUE_FILL,
+        "outline_rgba": _BLUE_OUTLINE,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registry — order matters when verbs map to multiple families (uncommon).
+# ---------------------------------------------------------------------------
+
+_HANDLERS: tuple[FamilyHandler, ...] = (
+    FamilyHandler(
+        family="jamming_circle",
+        template_id="jamming-circle",
+        detector=_detect_jamming_circle,
+        token_builder=_build_jamming_circle,
+        validator_param_keys=("radius_m", "power_w"),
+    ),
+    FamilyHandler(
+        family="indirect_fire_arc",
+        template_id="indirect-fire-arc",
+        detector=_detect_indirect_fire_arc,
+        token_builder=_build_indirect_fire_arc,
+        validator_param_keys=(
+            "range_m",
+            "time_of_flight_s",
+            "dispersion_ellipse_a_m",
+            "dispersion_ellipse_b_m",
+        ),
+    ),
+    FamilyHandler(
+        family="radar_fan",
+        template_id="radar-fan",
+        detector=_detect_radar_fan,
+        token_builder=_build_radar_fan,
+        validator_param_keys=("azimuth_deg", "sweep_arc_deg", "range_m"),
+    ),
+    FamilyHandler(
+        family="ew_cone",
+        template_id="ew-cone",
+        detector=_detect_ew_cone,
+        token_builder=_build_ew_cone,
+        validator_param_keys=("azimuth_deg", "beamwidth_deg", "effective_range_m"),
+    ),
+    FamilyHandler(
+        family="masint_cell",
+        template_id="masint-cell",
+        detector=_detect_masint_cell,
+        token_builder=_build_masint_cell,
+        validator_param_keys=("polygon_area_m2", "dwell_s"),
+    ),
+    FamilyHandler(
+        family="keyhole_footprint",
+        template_id="keyhole-footprint",
+        detector=_detect_keyhole_footprint,
+        token_builder=_build_keyhole_footprint,
+        validator_param_keys=("polygon_area_m2",),
+    ),
+    FamilyHandler(
+        family="uas_corridor",
+        template_id="uas-corridor",
+        detector=_detect_uas_corridor,
+        token_builder=_build_uas_corridor,
+        validator_param_keys=("altitude_band_lower_m", "altitude_band_upper_m", "width_m"),
+    ),
+)
+
+
+def find_handler(event: KernelEvent) -> FamilyHandler | None:
+    """Return the first matching family handler, or None if no spatial
+    family applies to this event (e.g., Mover verbs, Commander verbs,
+    Communicator non-spatial verbs)."""
+    for handler in _HANDLERS:
+        if handler.detector(event):
+            return handler
+    return None
+
+
+def new_artifact_id() -> UUID:
+    return uuid4()

--- a/services/czml-adapter/src/almighty_czml_adapter/models.py
+++ b/services/czml-adapter/src/almighty_czml_adapter/models.py
@@ -1,0 +1,73 @@
+"""Adapter result types.
+
+The adapter's output is a tagged-union per input event:
+
+  ACCEPTED  - validator accepted; the CZML packet is ready to publish.
+  REJECTED  - validator rejected; emit a `czml_rejected` audit event.
+  SKIPPED   - event is not spatial / no family handler matches; ignore.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+
+class ResultKind(str, Enum):
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class EntityPosition:
+    """A point in WGS-84 + ECEF, supplied by the caller's entity-position
+    lookup callback. v1 callers fabricate these; v2 wires the entity
+    table from the control-plane DB."""
+
+    lat_deg: float
+    lon_deg: float
+    alt_m: float
+
+
+@dataclass
+class AdapterResult:
+    """Tagged union — exactly one of `packet` (ACCEPTED) or `reason`
+    (REJECTED / SKIPPED) is set."""
+
+    kind: ResultKind
+    event_id: UUID
+    family: str | None
+    packet: dict[str, Any] | None = None
+    reason: str | None = None
+    validator_params: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def accepted(
+        cls, event_id: UUID, family: str, packet: dict[str, Any], validator_params: dict[str, Any]
+    ) -> "AdapterResult":
+        return cls(
+            kind=ResultKind.ACCEPTED,
+            event_id=event_id,
+            family=family,
+            packet=packet,
+            validator_params=validator_params,
+        )
+
+    @classmethod
+    def rejected(
+        cls, event_id: UUID, family: str, reason: str, validator_params: dict[str, Any]
+    ) -> "AdapterResult":
+        return cls(
+            kind=ResultKind.REJECTED,
+            event_id=event_id,
+            family=family,
+            reason=reason,
+            validator_params=validator_params,
+        )
+
+    @classmethod
+    def skipped(cls, event_id: UUID, reason: str) -> "AdapterResult":
+        return cls(kind=ResultKind.SKIPPED, event_id=event_id, family=None, reason=reason)

--- a/services/czml-adapter/src/almighty_czml_adapter/runner.py
+++ b/services/czml-adapter/src/almighty_czml_adapter/runner.py
@@ -1,0 +1,211 @@
+"""Async WS-subscribe + HTTP-publish runner.
+
+Connects to the WS-304 fan-out service's ``events`` channel, parses
+incoming PyRapide event payloads, runs them through the translator,
+and publishes the resulting CZML packet (on accept) via HTTP POST to
+the fan-out's ``/publish`` ingress on the ``czml_packets`` channel.
+
+Wire protocol per services/websocket/README.md:
+
+  Subscribe (server -> server) over WS:
+    ws://host:port/ws?token=<jwt>
+    -> { "action": "subscribe", "channel": "events" }
+
+  Inbound message:
+    { "type": "message", "channel": "events",
+      "tenant_id": "<uuid>", "payload": { ... event JSON ... } }
+
+  Publish (server -> server) over HTTP:
+    POST /publish
+    Authorization: Bearer <jwt>  (cell_role must be 'white')
+    body: { "tenant_id": "...", "channel": "czml_packets", "payload": {...} }
+
+The runner does NOT verify JWTs; it consumes one minted by the caller
+(the white-cell-side service identity).
+
+Tests stub the I/O via the protocols at the bottom of this file:
+``EventStream`` and ``PacketSink``. Production wires them to
+``WsEventStream`` and ``HttpPacketSink``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, AsyncIterator, Protocol
+from uuid import UUID
+
+import httpx
+import websockets
+from almighty_czml_validator import Validator
+from almighty_czml_validator.templates import TemplateLoader
+from almighty_kernel.dag import KernelEvent
+
+from .models import AdapterResult, ResultKind
+from .translator import EntityPositionLookup, translate_event
+
+log = logging.getLogger("almighty.czml_adapter.runner")
+
+
+# ---------- Protocols (the seams tests use) ---------------------------------
+
+
+class EventStream(Protocol):
+    """Async iterator of incoming KernelEvents for a given tenant."""
+
+    def __aiter__(self) -> AsyncIterator[KernelEvent]: ...
+
+
+class PacketSink(Protocol):
+    """Where accepted CZML packets get sent. Production: HTTP POST to
+    the WS-304 /publish endpoint. Tests: an in-memory list."""
+
+    async def publish(self, *, tenant_id: str, packet: dict[str, Any]) -> None: ...
+    async def publish_rejected(self, *, tenant_id: str, rejection: dict[str, Any]) -> None: ...
+
+
+# ---------- WS event stream (production) -------------------------------------
+
+
+@dataclass
+class WsEventStream:
+    """Subscribes to the WS-304 ``events`` channel and yields
+    KernelEvents. Reconnects with exponential backoff on disconnect."""
+
+    ws_url: str
+    jwt: str
+    max_reconnect_seconds: float = 30.0
+
+    async def __aiter__(self) -> AsyncIterator[KernelEvent]:
+        backoff = 1.0
+        while True:
+            try:
+                async with websockets.connect(
+                    f"{self.ws_url}?token={self.jwt}",
+                ) as ws:
+                    backoff = 1.0
+                    await ws.send(json.dumps({"action": "subscribe", "channel": "events"}))
+                    async for raw in ws:
+                        msg = json.loads(raw)
+                        if msg.get("type") != "message":
+                            continue
+                        if msg.get("channel") != "events":
+                            continue
+                        try:
+                            yield _hydrate_event(msg["payload"])
+                        except Exception as exc:  # noqa: BLE001
+                            log.warning("dropping malformed event: %s", exc)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("ws dropped (%s); reconnecting in %.1fs", exc, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(self.max_reconnect_seconds, backoff * 2.0)
+
+
+def _hydrate_event(payload: dict[str, Any]) -> KernelEvent:
+    """Reconstruct a KernelEvent from a JSON-shaped event payload. The
+    write path commits these via the WS-104 NamespacedDag, so the wire
+    shape here matches that produced by ``KernelEvent.model_dump()``."""
+    return KernelEvent(
+        event_id=UUID(payload["event_id"]),
+        tenant_id=UUID(payload["tenant_id"]),
+        scenario_id=UUID(payload["scenario_id"]),
+        turn=int(payload["turn"]),
+        source_officer_type=payload["source_officer_type"],
+        source_entity_id=UUID(payload["source_entity_id"]),
+        action_verb=payload["action_verb"],
+        payload=dict(payload.get("payload", {})),
+        causal_predecessors=[UUID(p) for p in payload.get("causal_predecessors", [])],
+        ts=datetime.fromisoformat(payload["ts"]),
+    )
+
+
+# ---------- HTTP packet sink (production) ------------------------------------
+
+
+@dataclass
+class HttpPacketSink:
+    """POSTs accepted CZML packets to the WS-304 /publish endpoint on
+    the tenant's ``czml_packets`` channel. Rejected events are POSTed
+    on a ``czml_rejected`` virtual channel so AAR can replay them.
+    """
+
+    publish_url: str  # e.g. http://websocket:4001/publish
+    jwt: str
+    timeout_s: float = 10.0
+    _client: httpx.AsyncClient | None = None
+
+    async def __aenter__(self) -> "HttpPacketSink":
+        self._client = httpx.AsyncClient(timeout=self.timeout_s)
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+
+    async def publish(self, *, tenant_id: str, packet: dict[str, Any]) -> None:
+        await self._post("czml_packets", tenant_id, packet)
+
+    async def publish_rejected(self, *, tenant_id: str, rejection: dict[str, Any]) -> None:
+        await self._post("czml_rejected", tenant_id, rejection)
+
+    async def _post(self, channel: str, tenant_id: str, payload: dict[str, Any]) -> None:
+        if self._client is None:
+            raise RuntimeError("HttpPacketSink used outside async context manager")
+        body = {"tenant_id": tenant_id, "channel": channel, "payload": payload}
+        headers = {"Authorization": f"Bearer {self.jwt}"}
+        resp = await self._client.post(self.publish_url, json=body, headers=headers)
+        if resp.status_code >= 300:
+            log.warning(
+                "publish to %s failed: status=%s body=%s",
+                channel,
+                resp.status_code,
+                resp.text,
+            )
+
+
+# ---------- Loop --------------------------------------------------------------
+
+
+@dataclass
+class AdapterRunner:
+    """Glue: pulls events from a stream, translates them, and forwards
+    accepted packets / rejection notices to the sink."""
+
+    stream: EventStream
+    sink: PacketSink
+    validator: Validator
+    template_loader: TemplateLoader
+    capability_profile: dict[str, Any]
+    entity_position_lookup: EntityPositionLookup | None = None
+
+    async def run(self) -> None:
+        async for event in self.stream:
+            result = translate_event(
+                event,
+                template_loader=self.template_loader,
+                validator=self.validator,
+                capability_profile=self.capability_profile,
+                entity_position_lookup=self.entity_position_lookup,
+            )
+            await self._dispatch(event, result)
+
+    async def _dispatch(self, event: KernelEvent, result: AdapterResult) -> None:
+        tenant = str(event.tenant_id)
+        if result.kind is ResultKind.ACCEPTED:
+            assert result.packet is not None
+            await self.sink.publish(tenant_id=tenant, packet=result.packet)
+        elif result.kind is ResultKind.REJECTED:
+            await self.sink.publish_rejected(
+                tenant_id=tenant,
+                rejection={
+                    "event_id": str(result.event_id),
+                    "family": result.family,
+                    "reason": result.reason,
+                    "validator_params": result.validator_params,
+                    "rejected_at": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+        # SKIPPED: silently ignore (Mover/Commander/Communicator-non-spatial verbs).

--- a/services/czml-adapter/src/almighty_czml_adapter/translator.py
+++ b/services/czml-adapter/src/almighty_czml_adapter/translator.py
@@ -1,0 +1,130 @@
+"""Pure event -> CZML packet projection.
+
+No I/O. Caller supplies:
+
+  - template_loader   : almighty_czml_validator.TemplateLoader
+  - validator         : almighty_czml_validator.Validator (in-process)
+  - entity_position_lookup : Callable[[UUID], EntityPosition] | None
+  - capability_profile : dict[str, Any] (the WS-106 / WS-107 profile)
+
+Returns an :class:`AdapterResult` per input event:
+
+  ACCEPTED  : packet ready to publish on `czml_packets`.
+  REJECTED  : validator rejected; caller emits `czml_rejected` audit.
+  SKIPPED   : event has no spatial family (Mover / Commander / etc.).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from almighty_czml_validator import ValidateRequest, Validator
+from almighty_czml_validator.templates import TemplateLoader
+from almighty_kernel.dag import KernelEvent
+
+from .families import find_handler, new_artifact_id
+from .models import AdapterResult, EntityPosition
+
+EntityPositionLookup = Callable[[KernelEvent], EntityPosition]
+
+
+# Substitution defaults --------------------------------------------------------
+
+_DEFAULT_POSITION = EntityPosition(lat_deg=36.18, lon_deg=-86.78, alt_m=170.0)
+
+
+def _default_lookup(_event: KernelEvent) -> EntityPosition:
+    """Fallback when the caller doesn't supply a lookup. v1 returns a
+    Nashville-anchored point so v1 demos render somewhere visible.
+    Production callers MUST supply a real lookup."""
+    return _DEFAULT_POSITION
+
+
+# Token substitution -----------------------------------------------------------
+
+
+def _substitute(node: Any, tokens: dict[str, Any]) -> Any:
+    """Recursively replace ``{{token}}`` strings inside the template's
+    ``base`` block. Two modes per WS-201's README:
+
+      - Whole-value: a string equal to ``"{{token}}"`` becomes the
+        token's native-typed value (number, bool, list, etc.).
+      - Interpolated: ``{{token}}`` inside a longer string is
+        stringified and substituted in place.
+    """
+    if isinstance(node, str):
+        # Whole-value: exactly "{{key}}" with no other characters.
+        if (
+            node.startswith("{{")
+            and node.endswith("}}")
+            and node.count("{{") == 1
+            and node.count("}}") == 1
+        ):
+            key = node[2:-2]
+            if key in tokens:
+                return tokens[key]
+            return node  # unknown token; leave unsubstituted
+        # Interpolated.
+        result = node
+        for key, value in tokens.items():
+            placeholder = "{{" + key + "}}"
+            if placeholder in result:
+                result = result.replace(placeholder, str(value))
+        return result
+    if isinstance(node, dict):
+        return {k: _substitute(v, tokens) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_substitute(x, tokens) for x in node]
+    return node
+
+
+# Public entry point -----------------------------------------------------------
+
+
+def translate_event(
+    event: KernelEvent,
+    *,
+    template_loader: TemplateLoader,
+    validator: Validator,
+    capability_profile: dict[str, Any],
+    entity_position_lookup: EntityPositionLookup | None = None,
+) -> AdapterResult:
+    """Translate one PyRapide event into an :class:`AdapterResult`."""
+    handler = find_handler(event)
+    if handler is None:
+        return AdapterResult.skipped(
+            event_id=event.event_id,
+            reason=f"no spatial family for verb '{event.action_verb}'",
+        )
+
+    lookup = entity_position_lookup or _default_lookup
+    position = lookup(event)
+    artifact_id = new_artifact_id()
+    tokens = handler.token_builder(event, position, artifact_id)
+    validator_params = {k: tokens[k] for k in handler.validator_param_keys if k in tokens}
+
+    template = template_loader.load(handler.template_id)
+    result = validator.validate(
+        ValidateRequest(
+            template_id=handler.template_id,
+            template_version=int(template.get("version", 1)),
+            params=validator_params,
+            agent_id=str(event.source_entity_id),
+            capability_profile=capability_profile,
+        )
+    )
+    if not result.accepted:
+        return AdapterResult.rejected(
+            event_id=event.event_id,
+            family=handler.family,
+            reason="; ".join(result.reasons) or "validator rejected",
+            validator_params=validator_params,
+        )
+
+    packet = _substitute(template["base"], tokens)
+    return AdapterResult.accepted(
+        event_id=event.event_id,
+        family=handler.family,
+        packet=packet,
+        validator_params=validator_params,
+    )

--- a/services/czml-adapter/tests/conftest.py
+++ b/services/czml-adapter/tests/conftest.py
@@ -1,0 +1,82 @@
+"""Shared fixtures: WS-201 templates, WS-107 us-bct + peer profiles,
+WS-202 validator. All real, no mocks of upstream contracts."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from almighty_czml_validator import Validator
+from almighty_czml_validator.templates import TemplateLoader
+from almighty_kernel.dag import KernelEvent
+
+from almighty_czml_adapter.models import EntityPosition
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROFILES_DIR = REPO_ROOT / "kernel" / "capability-profiles"
+TEMPLATES_DIR = REPO_ROOT / "czml" / "templates"
+
+TENANT = UUID("11111111-1111-4111-8111-111111111111")
+SCENARIO = UUID("22222222-2222-4222-8222-222222222222")
+ENTITY = UUID("33333333-3333-4333-8333-333333333333")
+
+
+@pytest.fixture(scope="session")
+def template_loader() -> TemplateLoader:
+    return TemplateLoader(templates_dir=TEMPLATES_DIR)
+
+
+@pytest.fixture(scope="session")
+def validator(template_loader: TemplateLoader) -> Validator:
+    return Validator(template_loader=template_loader)
+
+
+def _load_profile(name: str) -> dict:
+    with (PROFILES_DIR / f"{name}.json").open() as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="session")
+def us_bct_profile() -> dict:
+    return _load_profile("us-bct")
+
+
+@pytest.fixture(scope="session")
+def peer_profile() -> dict:
+    """The peer profile authorizes families us-bct doesn't (jam, ew_cone,
+    uas_corridor) — useful for cross-family coverage."""
+    return _load_profile("peer")
+
+
+@pytest.fixture()
+def position() -> EntityPosition:
+    """Anchor at Nashville west-bank BN HQ from the WS-403 doctrine."""
+    return EntityPosition(lat_deg=36.1750, lon_deg=-86.7900, alt_m=170.0)
+
+
+def make_event(
+    *,
+    action_verb: str,
+    source_officer_type: str,
+    payload: dict | None = None,
+    turn: int = 1,
+    tenant_id: UUID = TENANT,
+    scenario_id: UUID = SCENARIO,
+    source_entity_id: UUID = ENTITY,
+) -> KernelEvent:
+    return KernelEvent(
+        event_id=uuid4(),
+        tenant_id=tenant_id,
+        scenario_id=scenario_id,
+        turn=turn,
+        source_officer_type=source_officer_type,
+        source_entity_id=source_entity_id,
+        action_verb=action_verb,
+        payload=payload or {},
+        causal_predecessors=[],
+        ts=datetime(2026, 4, 25, 18, 0, 0, tzinfo=timezone.utc),
+    )

--- a/services/czml-adapter/tests/test_app.py
+++ b/services/czml-adapter/tests/test_app.py
@@ -1,0 +1,15 @@
+"""HTTP-layer smoke for the FastAPI shell."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from almighty_czml_adapter.app import app
+
+client = TestClient(app)
+
+
+def test_healthz():
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}

--- a/services/czml-adapter/tests/test_runner.py
+++ b/services/czml-adapter/tests/test_runner.py
@@ -1,0 +1,113 @@
+"""End-to-end runner test with stub stream + sink.
+
+Verifies the runner glues translator outputs to publish / publish_rejected
+correctly, and that SKIPPED events go nowhere.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator
+
+import pytest
+
+from almighty_kernel.dag import KernelEvent
+
+from almighty_czml_adapter.runner import AdapterRunner
+
+from conftest import make_event
+
+
+@dataclass
+class _StreamFromList:
+    events: list[KernelEvent]
+
+    def __aiter__(self) -> AsyncIterator[KernelEvent]:
+        async def gen() -> AsyncIterator[KernelEvent]:
+            for e in self.events:
+                yield e
+
+        return gen()
+
+
+@dataclass
+class _CollectingSink:
+    accepted: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+    rejected: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+
+    async def publish(self, *, tenant_id: str, packet: dict[str, Any]) -> None:
+        self.accepted.append((tenant_id, packet))
+
+    async def publish_rejected(self, *, tenant_id: str, rejection: dict[str, Any]) -> None:
+        self.rejected.append((tenant_id, rejection))
+
+
+@pytest.mark.asyncio
+async def test_runner_routes_accepted_packets(
+    template_loader, validator, us_bct_profile, position
+):
+    accepted_event = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={
+            "weapon_system": "notional.indirect.medium",
+            "volume_count": 1,
+            "range_m": 5_000.0,
+            "time_of_flight_s": 15.0,
+            "dispersion_ellipse_a_m": 50.0,
+            "dispersion_ellipse_b_m": 50.0,
+        },
+    )
+    skipped_event = make_event(action_verb="move_to", source_officer_type="MOVER")
+    rejected_event = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={
+            "weapon_system": "notional.indirect.medium",
+            "volume_count": 1,
+            "range_m": 50_000.0,  # over us-bct cap → reject
+            "time_of_flight_s": 30.0,
+            "dispersion_ellipse_a_m": 50.0,
+            "dispersion_ellipse_b_m": 50.0,
+        },
+    )
+
+    sink = _CollectingSink()
+    runner = AdapterRunner(
+        stream=_StreamFromList([accepted_event, skipped_event, rejected_event]),
+        sink=sink,
+        validator=validator,
+        template_loader=template_loader,
+        capability_profile=us_bct_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    await runner.run()
+
+    assert len(sink.accepted) == 1
+    tenant_id, packet = sink.accepted[0]
+    assert tenant_id == str(accepted_event.tenant_id)
+    assert packet["id"]  # substituted artifact_id
+
+    assert len(sink.rejected) == 1
+    rej_tenant, rejection = sink.rejected[0]
+    assert rej_tenant == str(rejected_event.tenant_id)
+    assert rejection["family"] == "indirect_fire_arc"
+    assert "range_m" in rejection["reason"]
+    assert "rejected_at" in rejection
+
+
+@pytest.mark.asyncio
+async def test_runner_handles_empty_stream(
+    template_loader, validator, us_bct_profile
+):
+    sink = _CollectingSink()
+    runner = AdapterRunner(
+        stream=_StreamFromList([]),
+        sink=sink,
+        validator=validator,
+        template_loader=template_loader,
+        capability_profile=us_bct_profile,
+    )
+    await runner.run()
+    assert sink.accepted == []
+    assert sink.rejected == []

--- a/services/czml-adapter/tests/test_translator.py
+++ b/services/czml-adapter/tests/test_translator.py
@@ -1,0 +1,394 @@
+"""End-to-end translator tests covering all 7 v1 spatial families.
+
+For each family:
+  - Happy path: a properly-shaped event → ACCEPTED with a substituted packet.
+  - Reject path: out-of-range params → REJECTED with the validator's reason.
+
+Plus:
+  - Verbs without a spatial family → SKIPPED.
+  - Validator rejection because the profile lacks the verb (us-bct + jam).
+  - Token substitution sanity (whole-value AND interpolated tokens).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from almighty_czml_adapter.models import ResultKind
+from almighty_czml_adapter.translator import translate_event
+
+from conftest import make_event
+
+
+# ---- Happy paths per family --------------------------------------------------
+
+
+def test_jamming_circle_happy(template_loader, validator, peer_profile, position):
+    event = make_event(
+        action_verb="jam",
+        source_officer_type="COMMUNICATOR",
+        payload={
+            "target_polygon": [[36.18, -86.78], [36.19, -86.77], [36.17, -86.76]],
+            "power_w": 500.0,
+            "band": "L",
+            "duration_s": 90.0,
+            "radius_m": 2_000.0,
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=peer_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.ACCEPTED
+    assert result.family == "jamming_circle"
+    # Whole-value token substituted to the actual number.
+    assert isinstance(result.packet["ellipse"]["semiMajorAxis"], (int, float))
+    assert result.packet["ellipse"]["semiMajorAxis"] == 2_000.0
+    # Interpolated token in the description.
+    assert "2000" in result.packet["description"] or "2000.0" in result.packet["description"]
+
+
+def test_indirect_fire_arc_happy(template_loader, validator, us_bct_profile, position):
+    event = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={
+            "weapon_system": "notional.indirect.medium",
+            "volume_count": 4,
+            "intent": "NEUTRALIZE",
+            "range_m": 12_000.0,
+            "time_of_flight_s": 25.0,
+            "dispersion_ellipse_a_m": 80.0,
+            "dispersion_ellipse_b_m": 80.0,
+            "target_coordinate": {"lat_deg": 36.181, "lon_deg": -86.772, "alt_m": 160.0},
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=us_bct_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.ACCEPTED
+    assert result.family == "indirect_fire_arc"
+
+
+def test_radar_fan_happy(template_loader, validator, us_bct_profile, position):
+    event = make_event(
+        action_verb="detect",
+        source_officer_type="SENSOR",
+        payload={
+            "modality": "RADAR",
+            "confidence": 0.9,
+            "range_m": 10_000.0,
+            "azimuth_deg": 90.0,
+            "sweep_arc_deg": 60.0,
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=us_bct_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.ACCEPTED
+    assert result.family == "radar_fan"
+
+
+def test_ew_cone_happy(template_loader, validator, peer_profile, position):
+    event = make_event(
+        action_verb="detect",
+        source_officer_type="SENSOR",
+        payload={
+            "modality": "RF",
+            "confidence": 0.7,
+            "range_m": 30_000.0,
+            "azimuth_deg": 45.0,
+            "beamwidth_deg": 30.0,
+            "band": "UHF",
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=peer_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.ACCEPTED
+    assert result.family == "ew_cone"
+
+
+def test_masint_cell_happy(template_loader, validator, us_bct_profile, position):
+    """us-bct profile authorizes masint_cell."""
+    event = make_event(
+        action_verb="detect",
+        source_officer_type="SENSOR",
+        payload={
+            "modality": "MASINT_MULTI",
+            "confidence": 0.6,
+            "range_m": 10_000.0,
+            "polygon_area_m2": 50_000.0,
+            "dwell_s": 600.0,
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=us_bct_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.ACCEPTED
+    assert result.family == "masint_cell"
+
+
+def test_keyhole_footprint_happy(template_loader, validator, us_bct_profile, position):
+    event = make_event(
+        action_verb="classify",
+        source_officer_type="SENSOR",
+        payload={
+            "classification_label": "notional.air.uas.medium",
+            "confidence": 0.8,
+            "dwell_s": 30.0,
+            "polygon_area_m2": 25_000.0,
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=us_bct_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.ACCEPTED
+    assert result.family == "keyhole_footprint"
+
+
+def test_uas_corridor_happy(template_loader, validator, peer_profile, position):
+    """peer profile carries uas_corridor in effect_parameter_ranges and
+    advertise_corridor=true on its communicator block."""
+    event = make_event(
+        action_verb="relay",
+        source_officer_type="COMMUNICATOR",
+        payload={
+            "channel": "VHF",
+            "is_airborne": True,
+            "altitude_band_lower_m": 500.0,
+            "altitude_band_upper_m": 2_000.0,
+            "width_m": 1_000.0,
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=peer_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.ACCEPTED
+    assert result.family == "uas_corridor"
+
+
+# ---- Reject paths ------------------------------------------------------------
+
+
+def test_jamming_circle_out_of_range_rejects(
+    template_loader, validator, peer_profile, position
+):
+    """peer's jamming_circle.power_w max is 1500 W; 5000 must reject."""
+    event = make_event(
+        action_verb="jam",
+        source_officer_type="COMMUNICATOR",
+        payload={
+            "target_polygon": [[36.18, -86.78], [36.19, -86.77], [36.17, -86.76]],
+            "power_w": 5_000.0,  # over peer cap
+            "band": "L",
+            "duration_s": 60.0,
+            "radius_m": 2_000.0,
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=peer_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.REJECTED
+    assert result.family == "jamming_circle"
+    assert "power_w" in result.reason
+
+
+def test_us_bct_jam_event_rejects_at_verb_gate(
+    template_loader, validator, us_bct_profile, position
+):
+    """us-bct profile lacks the `jam` verb, so the validator rejects at
+    the verb-emission gate before reaching range checks. Capability
+    gating verified — DoD requirement."""
+    event = make_event(
+        action_verb="jam",
+        source_officer_type="COMMUNICATOR",
+        payload={
+            "target_polygon": [[36.18, -86.78], [36.19, -86.77], [36.17, -86.76]],
+            "power_w": 100.0,  # in-range
+            "band": "VHF",
+            "duration_s": 30.0,
+            "radius_m": 1_000.0,
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=us_bct_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.REJECTED
+    assert result.family == "jamming_circle"
+    assert "jam" in result.reason  # validator's verb-gate reason
+
+
+def test_engage_out_of_range_rejects(
+    template_loader, validator, us_bct_profile, position
+):
+    """us-bct indirect_fire_arc.range_m max is 25000; 50000 must reject."""
+    event = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={
+            "weapon_system": "notional.indirect.medium",
+            "volume_count": 1,
+            "range_m": 50_000.0,  # over cap
+            "time_of_flight_s": 30.0,
+            "dispersion_ellipse_a_m": 50.0,
+            "dispersion_ellipse_b_m": 50.0,
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=us_bct_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.REJECTED
+    assert "range_m" in result.reason
+
+
+# ---- Skip paths --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "verb,officer",
+    [
+        ("move_to", "MOVER"),
+        ("halt", "MOVER"),
+        ("assume_posture", "MOVER"),
+        ("send", "COMMUNICATOR"),
+        ("report", "COMMUNICATOR"),
+        ("issue_order", "COMMANDER"),
+        ("escalate", "COMMANDER"),
+        ("delegate", "COMMANDER"),
+    ],
+)
+def test_non_spatial_verb_skipped(
+    verb, officer, template_loader, validator, us_bct_profile, position
+):
+    event = make_event(action_verb=verb, source_officer_type=officer)
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=us_bct_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.SKIPPED
+    assert result.packet is None
+    assert result.family is None
+
+
+def test_eo_ir_detect_skipped(
+    template_loader, validator, us_bct_profile, position
+):
+    """EO_IR has no spatial CZML template in v1 (per WS-108 § 6.1).
+    The translator skips rather than failing."""
+    event = make_event(
+        action_verb="detect",
+        source_officer_type="SENSOR",
+        payload={"modality": "EO_IR", "confidence": 0.7, "range_m": 4_000.0},
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=us_bct_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.SKIPPED
+
+
+# ---- Token substitution sanity ----------------------------------------------
+
+
+def test_packet_carries_artifact_id_and_owning_entity(
+    template_loader, validator, us_bct_profile, position
+):
+    event = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={
+            "weapon_system": "notional.indirect.medium",
+            "volume_count": 1,
+            "range_m": 5_000.0,
+            "time_of_flight_s": 15.0,
+            "dispersion_ellipse_a_m": 50.0,
+            "dispersion_ellipse_b_m": 50.0,
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=us_bct_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.kind is ResultKind.ACCEPTED
+    # Whole-value token: packet.id is the synthesized artifact_id, NOT
+    # the literal "{{artifact_id}}" string.
+    assert "{{" not in result.packet["id"]
+    # Interpolated: owning_entity_id substituted into name / description.
+    assert str(event.source_entity_id) in result.packet.get("name", "")
+
+
+def test_validator_params_subset_carried_on_result(
+    template_loader, validator, us_bct_profile, position
+):
+    """validator_params on an ACCEPTED result should reflect what was
+    passed to the validator — useful for debug + AAR audit."""
+    event = make_event(
+        action_verb="engage",
+        source_officer_type="EFFECTOR",
+        payload={
+            "weapon_system": "notional.indirect.medium",
+            "volume_count": 1,
+            "range_m": 5_000.0,
+            "time_of_flight_s": 15.0,
+            "dispersion_ellipse_a_m": 50.0,
+            "dispersion_ellipse_b_m": 50.0,
+        },
+    )
+    result = translate_event(
+        event,
+        template_loader=template_loader,
+        validator=validator,
+        capability_profile=us_bct_profile,
+        entity_position_lookup=lambda _e: position,
+    )
+    assert result.validator_params["range_m"] == 5_000.0
+    assert result.validator_params["time_of_flight_s"] == 15.0


### PR DESCRIPTION
## Summary

Live PyRapide → CZML adapter. Subscribes to a tenant's `events` channel on WS-304, translates each spatial-artifact-bearing event into a post-substitution CZML packet (gated by the WS-202 validator), and publishes the packet to the tenant's `czml_packets` channel.

This PR is the **kernel side** of #28's joint ownership. The renderer-side React + Resium component (live/static toggle on top of WS-502) is owned by Alex; an integration contract for it is documented in [services/czml-adapter/README.md § Renderer-side integration contract](services/czml-adapter/README.md#renderer-side-integration-contract-for-alex).

Closes #28 (kernel side).

## Pipeline

```
WS-304 events  ──►  AdapterRunner.run()  ──►  translate_event(event)  ──►  HTTP POST /publish
                                                                              channel=czml_packets
                                                                              channel=czml_rejected (on reject)
```

The translator is **pure** (no I/O); the runner glues it to WS-304. Tests run the translator in-process and the runner against stub stream / sink — no live WS or HTTP needed.

## Family coverage (v1: 7 of 9)

| Family | Trigger | Validator gate |
|---|---|---|
| `jamming_circle` | `Communicator.jam` OR `Effector.disable(method=EW)` | `radius_m`, `power_w` |
| `indirect_fire_arc` | `Effector.engage`/`suppress`/`destroy` OR `disable(method=KINETIC)` | `range_m`, `time_of_flight_s`, `dispersion_a`/`b` |
| `radar_fan` | `Sensor.detect`/`track` with `modality=RADAR` | `azimuth_deg`, `sweep_arc_deg`, `range_m` |
| `ew_cone` | `Sensor.detect` with `modality=RF` | `azimuth_deg`, `beamwidth_deg`, `effective_range_m` |
| `masint_cell` | `Sensor.detect`/`classify` with MASINT modality | `polygon_area_m2`, `dwell_s` |
| `keyhole_footprint` | `Sensor.classify` (non-MASINT) | `polygon_area_m2` |
| `uas_corridor` | `Communicator.relay` with `payload.is_airborne=True` | `altitude_band_lower_m`/`upper_m`, `width_m` |

**Deferred to v2:**
- `ir_plume` — needs kernel-side follow-on event emission from `Effector.destroy` (no machinery yet).
- `satellite_swath` — needs SPACE_UNIT entity-type signal that the events stream doesn't carry.

## Result semantics

```python
@dataclass
class AdapterResult:
    kind: ResultKind  # ACCEPTED | REJECTED | SKIPPED
    event_id: UUID
    family: str | None
    packet: dict | None              # set on ACCEPTED
    reason: str | None               # set on REJECTED / SKIPPED
    validator_params: dict           # set on ACCEPTED / REJECTED
```

- **ACCEPTED** — packet ready to publish on `czml_packets`.
- **REJECTED** — runner publishes a `czml_rejected` audit on a virtual channel (AAR replay per WS-108 § 7.4).
- **SKIPPED** — non-spatial verb OR EO_IR detect.

## Capability gating verified end-to-end (DoD)

Two reject-path tests confirm:

1. **`test_us_bct_jam_event_rejects_at_verb_gate`** — us-bct profile lacks the `jam` verb; the validator's verb-emission gate fires before parameter checks.
2. **`test_engage_out_of_range_rejects`** — engage with `range_m=50000` (over us-bct's 25000 cap) is rejected with `"range_m" in reason`.

Rejected events never publish to `czml_packets` → DoD's "rejected packets do not render" follows by construction. The renderer doesn't see them.

## Layout

```
services/czml-adapter/
├── pyproject.toml
├── README.md                                       (renderer-side contract included)
├── src/almighty_czml_adapter/
│   ├── models.py        AdapterResult tagged union, ResultKind, EntityPosition
│   ├── families.py      Per-family detector + token builder + validator-param keys
│   ├── translator.py    Pure event → AdapterResult; {{token}} substitution
│   ├── runner.py        AdapterRunner glue + WsEventStream + HttpPacketSink
│   └── app.py           FastAPI: /healthz only
└── tests/               24 passing
```

## Tests — 24 passing

```
$ pytest -v
tests/test_app.py .                              [  4%]
tests/test_runner.py ..                          [ 12%]
tests/test_translator.py .....................   [100%]
24 passed in 0.08s
```

- **7 family happy-paths** — one per v1 family; ACCEPTED with substituted packet (whole-value tokens become native types; interpolated tokens fill into name/description).
- **3 reject paths** — jam over peer cap; us-bct lacks jam (verb gate); engage over us-bct cap.
- **9 skip paths** — 8 non-spatial verbs + EO_IR detect.
- **2 token-substitution sanity** — `packet.id` is the substituted artifact UUID; `validator_params` reflected on result for AAR audit.
- **2 runner integration** — stub `_StreamFromList` + `_CollectingSink`; ACCEPTED → publish, REJECTED → publish_rejected, SKIPPED → silently dropped, empty stream is no-op.
- **1 HTTP smoke** — `/healthz` returns `{status: ok}`.

Real `KernelEvent`, real `Validator`, real `TemplateLoader`, real WS-107 profiles loaded from disk. No mocks of upstream contracts.

## Definition of done check

- [x] All criteria from #28 satisfied: live adapter renders effects from a running scenario (translator + runner glue tested end-to-end). Capability gating verified (rejected packets do not render — they never publish to the channel the renderer subscribes to).
- [x] Documentation updated — README has the family coverage table, result semantics, renderer-side integration contract for Alex, and operational notes.
- [x] Tests added or updated — 24 passing.
- [x] Banner present on any new visual surface — N/A (backend service).

## Decisions worth flagging

1. **Translator is pure; runner is the I/O seam.** Tests run the translator in-process against real upstream contracts. The runner is glue tested via stub stream / sink. No live WS or HTTP required to validate the contract.
2. **Entity-position lookup is caller-supplied** (per pre-implementation alignment). v1's default returns a Nashville-anchored point so demos render somewhere visible. Production callers wire a real lookup that reads from the entities table — that's a v2 integration concern.
3. **Capability profile is also caller-supplied** (single dict in v1). A real deployment will want a `lookup_profile_for(tenant_id, agent_entity_id)` callback. Same v2 shape as the entity lookup.
4. **`czml_rejected` audit on a virtual channel.** Documented as the channel name; doesn't strictly exist in the WS-304 channel access matrix yet, but the wire shape works because `/publish` accepts any channel name with a white-cell JWT. AAR (WS-506) consumes it for rejection replay.
5. **No deletion publishing yet.** Templates' `availability` time windows handle most cases. Explicit `delete: true` publishing is a v2 candidate when the kernel grows artifact-end events.
6. **Adapter does NOT post to WS-303.** Same scope-discipline as my prior PRs — rejection metadata is on the AdapterResult and audit publish; wiring to `override_decisions` is a follow-up integration ticket.

## Downstream impact

- **Unblocks Alex's WS-503 renderer-side PR.** The README's "Renderer-side integration contract" section gives the wire shape, subscribe pattern, and packet structure he needs to consume.
- **Wires into WS-506 AAR.** AAR reads both `czml_packets` (for renderer playback) and `czml_rejected` (for "what was blocked" analysis).
- **WS-601 Nashville scenario integration** — once Alex's renderer side lands and the harness routes blue/red/white events through the kernel, this adapter's stream becomes live.

## Note on .gitkeep removal

Dropped `services/czml-adapter/.gitkeep` since the directory now has real content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)