### PR TITLE
feat: AAR replay + control-plane events endpoint (WS-506)

### DIFF
--- a/services/control-plane/package.json
+++ b/services/control-plane/package.json
@@ -4,12 +4,12 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/server.ts",
+    "dev": "dotenv -e .env -- tsx watch src/server.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "migrate": "node-pg-migrate -m migrations -d DATABASE_URL up",
-    "migrate:test": "DATABASE_URL=$TEST_DATABASE_URL node-pg-migrate -m migrations -d DATABASE_URL up",
+    "migrate": "dotenv -e .env -- node-pg-migrate -m migrations -d DATABASE_URL up",
+    "migrate:test": "dotenv -e .env -- cross-env-shell DATABASE_URL=$TEST_DATABASE_URL node-pg-migrate -m migrations -d DATABASE_URL up",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -24,6 +24,8 @@
   "devDependencies": {
     "@types/node": "^22.10.5",
     "@types/pg": "^8.11.10",
+    "cross-env": "^7.0.3",
+    "dotenv-cli": "^7.4.4",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"

--- a/services/control-plane/package.json
+++ b/services/control-plane/package.json
@@ -14,6 +14,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fastify/cors": "^10.0.1",
     "@fastify/jwt": "^9.0.1",
     "fastify": "^5.1.0",
     "node-pg-migrate": "^7.9.0",

--- a/services/control-plane/pnpm-lock.yaml
+++ b/services/control-plane/pnpm-lock.yaml
@@ -33,6 +33,12 @@ importers:
       '@types/pg':
         specifier: ^8.11.10
         version: 8.20.0
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
+      dotenv-cli:
+        specifier: ^7.4.4
+        version: 7.4.4
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -627,6 +633,11 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -647,6 +658,18 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  dotenv-cli@7.4.4:
+    resolution: {integrity: sha512-XkBYCG0tPIes+YZr4SpfFv76SQrV/LeCE8CI7JSEMi3VR9MvTihCGTOtbIexD6i2mXF+6px7trb1imVCXSNMDw==}
+    hasBin: true
+
+  dotenv-expand@10.0.0:
+    resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
+    engines: {node: '>=12'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -785,6 +808,9 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -1537,6 +1563,10 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -1550,6 +1580,17 @@ snapshots:
   deep-eql@5.0.2: {}
 
   dequal@2.0.3: {}
+
+  dotenv-cli@7.4.4:
+    dependencies:
+      cross-spawn: 7.0.6
+      dotenv: 16.6.1
+      dotenv-expand: 10.0.0
+      minimist: 1.2.8
+
+  dotenv-expand@10.0.0: {}
+
+  dotenv@16.6.1: {}
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -1752,6 +1793,8 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
+
+  minimist@1.2.8: {}
 
   minipass@7.1.3: {}
 

--- a/services/control-plane/pnpm-lock.yaml
+++ b/services/control-plane/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fastify/cors':
+        specifier: ^10.0.1
+        version: 10.1.0
       '@fastify/jwt':
         specifier: ^9.0.1
         version: 9.1.0
@@ -338,6 +341,9 @@ packages:
 
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cors@10.1.0':
+    resolution: {integrity: sha512-MZyBCBJtII60CU9Xme/iE4aEy8G7QpzGR8zkdXZkDFt7ElEMachbE61tfhAG/bvSaULlqlf0huMT12T7iqEmdQ==}
 
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
@@ -783,6 +789,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mnemonist@0.40.0:
+    resolution: {integrity: sha512-kdd8AFNig2AD5Rkih7EPCXhu/iMvwevQFX/uEiGhZyPZi7fHqOoF4V4kHLpCfysxXMgQ4B52kdPMCwARshKvEg==}
 
   mnemonist@0.40.3:
     resolution: {integrity: sha512-Vjyr90sJ23CKKH/qPAgUKicw/v6pRoamxIEDFOF8uSgFME7DqPRpHgRTejWVjkdGg5dXj0/NyxZHZ9bcjH+2uQ==}
@@ -1294,6 +1303,11 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.20.0)
       fast-uri: 3.1.0
 
+  '@fastify/cors@10.1.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      mnemonist: 0.40.0
+
   '@fastify/error@4.2.0': {}
 
   '@fastify/fast-json-stringify-compiler@5.0.3':
@@ -1740,6 +1754,10 @@ snapshots:
       brace-expansion: 5.0.5
 
   minipass@7.1.3: {}
+
+  mnemonist@0.40.0:
+    dependencies:
+      obliterator: 2.0.5
 
   mnemonist@0.40.3:
     dependencies:

--- a/services/control-plane/src/app.ts
+++ b/services/control-plane/src/app.ts
@@ -1,5 +1,6 @@
 import Fastify, { type FastifyInstance } from "fastify";
 import fastifyJwt from "@fastify/jwt";
+import fastifyCors from "@fastify/cors";
 import { ZodError } from "zod";
 import type { Env } from "./config.js";
 import { createPool, type Pool } from "./db.js";
@@ -7,6 +8,7 @@ import { registerTenantRoutes } from "./routes/tenants.js";
 import { registerScenarioRoutes } from "./routes/scenarios.js";
 import { registerTurnRoutes } from "./routes/turns.js";
 import { registerOverrideRoutes } from "./routes/overrides.js";
+import { registerEventRoutes } from "./routes/events.js";
 
 export interface BuildAppOptions {
   env: Env;
@@ -19,6 +21,17 @@ export async function buildApp({ env, pool }: BuildAppOptions): Promise<{
 }> {
   const app = Fastify({ logger: { level: env.LOG_LEVEL } });
   const db = pool ?? createPool(env.DATABASE_URL);
+
+  // Permissive CORS for dev — the renderer (Vite on :5173) is on a different
+  // origin than the control-plane (:4000). v1 reflects the request origin and
+  // allows the Authorization header. Production should pin to a known origin
+  // list via env.
+  await app.register(fastifyCors, {
+    origin: true,
+    credentials: true,
+    allowedHeaders: ["content-type", "authorization"],
+    methods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+  });
 
   await app.register(fastifyJwt, { secret: env.JWT_SECRET });
 
@@ -36,6 +49,7 @@ export async function buildApp({ env, pool }: BuildAppOptions): Promise<{
   await registerScenarioRoutes(app, db);
   await registerTurnRoutes(app, db);
   await registerOverrideRoutes(app, db);
+  await registerEventRoutes(app, db);
 
   app.addHook("onClose", async () => {
     if (!pool) await db.end();

--- a/services/control-plane/src/routes/events.ts
+++ b/services/control-plane/src/routes/events.ts
@@ -1,0 +1,55 @@
+import type { FastifyInstance } from "fastify";
+import type { Pool } from "../db.js";
+import { requireAuth, requireOwnTenant } from "../auth.js";
+import { ScenarioIdParams } from "../types.js";
+
+// Read-only access to the committed event log for a scenario. Powers WS-506
+// AAR replay; populated by the kernel (WS-104 namespacing) once agents
+// (WS-401–405) commit events through the DAG.
+//
+// All cell roles within the tenant can read (review-only surface; mutations
+// happen via agent runtime, not here).
+export async function registerEventRoutes(app: FastifyInstance, db: Pool): Promise<void> {
+  app.get<{
+    Params: { id: string; sid: string };
+    Querystring: { since_ts?: string; until_ts?: string; limit?: string };
+  }>(
+    "/tenants/:id/scenarios/:sid/events",
+    { preHandler: [requireAuth, requireOwnTenant] },
+    async (req, reply) => {
+      ScenarioIdParams.parse(req.params);
+
+      const limitRaw = req.query.limit;
+      const limit = Math.min(
+        Number.isFinite(Number(limitRaw)) ? Number(limitRaw) : 5000,
+        10_000,
+      );
+      const sinceTs = req.query.since_ts ?? null;
+      const untilTs = req.query.until_ts ?? null;
+
+      const params: unknown[] = [req.params.id, req.params.sid];
+      const conds: string[] = ["tenant_id = $1", "scenario_id = $2"];
+      if (sinceTs) {
+        params.push(sinceTs);
+        conds.push(`ts >= $${params.length}`);
+      }
+      if (untilTs) {
+        params.push(untilTs);
+        conds.push(`ts <= $${params.length}`);
+      }
+      params.push(limit);
+
+      const result = await db.query(
+        `SELECT event_id, tenant_id, scenario_id, turn,
+                source_officer_type, source_entity_id, action_verb,
+                payload, causal_predecessors, ts, created_at
+         FROM events
+         WHERE ${conds.join(" AND ")}
+         ORDER BY ts ASC, event_id ASC
+         LIMIT $${params.length}`,
+        params,
+      );
+      return reply.send({ events: result.rows, count: result.rowCount });
+    },
+  );
+}

--- a/services/control-plane/tests/integration.test.ts
+++ b/services/control-plane/tests/integration.test.ts
@@ -282,3 +282,104 @@ describe("tenant lifecycle", () => {
     expect(list.json().tenants).toHaveLength(0);
   });
 });
+
+describe("GET /tenants/:id/scenarios/:sid/events (WS-506)", () => {
+  const SCENARIO_ID = "33333333-3333-4333-8333-333333333333";
+
+  async function seedEntity(entityId: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO entities (
+         entity_id, tenant_id, scenario_id, type_category, type_subtype_ref,
+         display_name, force_affiliation,
+         position_lat_deg, position_lon_deg, position_alt_m,
+         position_ecef_x_m, position_ecef_y_m, position_ecef_z_m,
+         velocity_ecef_vx_mps, velocity_ecef_vy_mps, velocity_ecef_vz_mps,
+         orientation_qw, orientation_qx, orientation_qy, orientation_qz,
+         capability_set_ref
+       ) VALUES (
+         $1, $2, $3, 'GROUND_UNIT', 'notional.test.unit',
+         'Test unit', 'BLUE',
+         36.18, -86.78, 200,
+         0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 'test@1'
+       )`,
+      [entityId, TENANT_A, SCENARIO_ID],
+    );
+  }
+
+  async function seedEvent(opts: { event_id: string; entity_id: string; turn: number; ts: string; verb?: string }): Promise<void> {
+    await pool.query(
+      `INSERT INTO events (
+         event_id, tenant_id, scenario_id, turn,
+         source_officer_type, source_entity_id, action_verb, payload,
+         causal_predecessors, ts
+       ) VALUES (
+         $1, $2, $3, $4, 'EFFECTOR', $5, $6, '{"target":"x"}'::jsonb, '{}'::uuid[], $7
+       )`,
+      [opts.event_id, TENANT_A, SCENARIO_ID, opts.turn, opts.entity_id, opts.verb ?? "engage", opts.ts],
+    );
+  }
+
+  beforeEach(async () => {
+    await seedTenant(TENANT_A, "Tenant A");
+    await seedTenant(TENANT_B, "Tenant B");
+    await pool.query(
+      `INSERT INTO scenarios (scenario_id, tenant_id, display_name) VALUES ($1, $2, $3)`,
+      [SCENARIO_ID, TENANT_A, "Demo scenario"],
+    );
+    const ENTITY = "44444444-4444-4444-8444-444444444444";
+    await seedEntity(ENTITY);
+    await seedEvent({ event_id: "55555555-5555-4555-8555-555555555501", entity_id: ENTITY, turn: 1, ts: "2026-04-25T22:00:00Z" });
+    await seedEvent({ event_id: "55555555-5555-4555-8555-555555555502", entity_id: ENTITY, turn: 1, ts: "2026-04-25T22:00:30Z", verb: "suppress" });
+    await seedEvent({ event_id: "55555555-5555-4555-8555-555555555503", entity_id: ENTITY, turn: 2, ts: "2026-04-25T22:01:00Z", verb: "destroy" });
+  });
+
+  it("returns events for own tenant + scenario, ordered by ts", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/tenants/${TENANT_A}/scenarios/${SCENARIO_ID}/events`,
+      headers: auth({ tenant_id: TENANT_A, cell_role: "blue" }),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.count).toBe(3);
+    expect(body.events.map((e: { action_verb: string }) => e.action_verb)).toEqual(["engage", "suppress", "destroy"]);
+  });
+
+  it.each(["white", "blue", "red", "observer"] as const)("%s can read events", async (role) => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/tenants/${TENANT_A}/scenarios/${SCENARIO_ID}/events`,
+      headers: auth({ tenant_id: TENANT_A, cell_role: role }),
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("denies cross-tenant read", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/tenants/${TENANT_A}/scenarios/${SCENARIO_ID}/events`,
+      headers: auth({ tenant_id: TENANT_B, cell_role: "white" }),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("filters by since_ts / until_ts", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/tenants/${TENANT_A}/scenarios/${SCENARIO_ID}/events?since_ts=2026-04-25T22:00:25Z&until_ts=2026-04-25T22:00:45Z`,
+      headers: auth({ tenant_id: TENANT_A, cell_role: "white" }),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.count).toBe(1);
+    expect(body.events[0].action_verb).toBe("suppress");
+  });
+
+  it("requires auth", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/tenants/${TENANT_A}/scenarios/${SCENARIO_ID}/events`,
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/web/renderer/src/api/aar.ts
+++ b/web/renderer/src/api/aar.ts
@@ -1,0 +1,166 @@
+// AAR (after-action review) data sources. Events come from the real
+// control-plane endpoint added in WS-506. Override decisions are still
+// synthetic — once WS-303 starts emitting `override_decision`-tagged events
+// into the events table, derive them from the same /events fetch.
+
+import { getStoredToken } from "../auth/jwt";
+
+export interface DagEvent {
+  event_id: string;
+  tenant_id: string;
+  scenario_id: string;
+  turn: number;
+  source_officer_type: "SENSOR" | "EFFECTOR" | "MOVER" | "COMMUNICATOR" | "COMMANDER";
+  source_entity_id: string;
+  action_verb: string;
+  payload: Record<string, unknown>;
+  causal_predecessors: string[];
+  ts: string; // ISO-8601
+  created_at: string;
+}
+
+export interface OverrideDecision {
+  decision_id: string;
+  ts: string;
+  scope: "per-event" | "per-agent-per-turn" | "per-turn";
+  target_id: string;
+  action: "review" | "auto-approve" | "auto-block";
+  rationale: string;
+  decided_by: string;
+}
+
+export interface AarEnvelope {
+  scenario: { tenant_id: string; scenario_id: string; replay_source: string };
+  events: DagEvent[];
+  override_decisions: OverrideDecision[];
+  generated_at: string;
+}
+
+const CONTROL_PLANE_BASE = (() => {
+  if (typeof window === "undefined") return "http://localhost:4000";
+  // Vite proxies aren't configured; for v1 the operator points the renderer at
+  // a known control-plane URL via env. Default localhost for dev.
+  return import.meta.env?.VITE_CONTROL_PLANE_URL ?? "http://localhost:4000";
+})();
+
+export async function fetchEvents(
+  tenantId: string,
+  scenarioId: string,
+  opts?: { since_ts?: string; until_ts?: string; limit?: number },
+): Promise<DagEvent[]> {
+  const token = getStoredToken();
+  if (!token) throw new Error("no JWT in localStorage; set one via DevTokenForm");
+
+  const url = new URL(`${CONTROL_PLANE_BASE}/tenants/${tenantId}/scenarios/${scenarioId}/events`);
+  if (opts?.since_ts) url.searchParams.set("since_ts", opts.since_ts);
+  if (opts?.until_ts) url.searchParams.set("until_ts", opts.until_ts);
+  if (opts?.limit) url.searchParams.set("limit", String(opts.limit));
+
+  const res = await fetch(url.toString(), {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`GET /events → ${res.status} ${res.statusText}`);
+  }
+  const body = (await res.json()) as { events: DagEvent[]; count: number };
+  return body.events;
+}
+
+/**
+ * Fixture event log for demo when /events returns empty. Mirrors the
+ * Nashville vignette's tactical sequence (per WS-204) so the AAR has
+ * something to scrub through before agents run for real.
+ */
+export function fixtureEvents(tenantId: string, scenarioId: string): DagEvent[] {
+  const t = (offsetSec: number): string =>
+    new Date(Date.parse("2026-04-25T22:00:00Z") + offsetSec * 1000).toISOString();
+  const E = "44444444-4444-4444-8444-440000000000";
+  const mk = (
+    n: number,
+    turn: number,
+    ts: string,
+    officer: DagEvent["source_officer_type"],
+    verb: string,
+    payload: Record<string, unknown>,
+  ): DagEvent => ({
+    event_id: `fixture-${String(n).padStart(4, "0")}`,
+    tenant_id: tenantId,
+    scenario_id: scenarioId,
+    turn,
+    source_officer_type: officer,
+    source_entity_id: E,
+    action_verb: verb,
+    payload,
+    causal_predecessors: [],
+    ts,
+    created_at: ts,
+  });
+
+  return [
+    mk(1, 1, t(0),    "MOVER",        "move_to",     { target_lat_deg: 36.20, target_lon_deg: -86.78, target_alt_m: 500 }),
+    mk(2, 1, t(60),   "COMMUNICATOR", "jam",         { center_lat_deg: 36.18, center_lon_deg: -86.81, radius_m: 2000, power_w: 600, band: "VHF" }),
+    mk(3, 2, t(120),  "SENSOR",       "detect",      { target_entity_id: E, modality: "RADAR", confidence: 0.82, range_m: 12000 }),
+    mk(4, 2, t(180),  "EFFECTOR",     "engage",      { target_lat_deg: 36.198, target_lon_deg: -86.762, weapon_system: "notional.indirect.medium", volume_count: 4 }),
+    mk(5, 3, t(240),  "SENSOR",       "classify",    { track_id: "trk-001", classification_label: "wheeled-EW", confidence: 0.74, dwell_s: 8 }),
+    mk(6, 3, t(300),  "EFFECTOR",     "destroy",     { target_entity_id: E, weapon_system: "notional.indirect.medium", volume_count: 8, justification: "Confirmed EW emitter; CARVER 21." }),
+    mk(7, 4, t(360),  "COMMANDER",    "report",      { report_type: "SITREP", to_echelon: "BRIGADE", report_payload: { summary: "EW threat neutralized; phase line PL Cumberland secured." } }),
+  ];
+}
+
+export function fixtureOverrideDecisions(): OverrideDecision[] {
+  const t = (offsetSec: number): string =>
+    new Date(Date.parse("2026-04-25T22:00:00Z") + offsetSec * 1000).toISOString();
+  return [
+    {
+      decision_id: "ovr-decision-0001",
+      ts: t(305),
+      scope: "per-event",
+      target_id: "fixture-0006",
+      action: "review",
+      rationale: "Effector.destroy on EW battery — held for white-cell adjudication; CARVER score reviewed and approved.",
+      decided_by: "white@demo",
+    },
+    {
+      decision_id: "ovr-decision-0002",
+      ts: t(125),
+      scope: "per-turn",
+      target_id: "2",
+      action: "auto-approve",
+      rationale: "Routine sensor + mover traffic for turn 2 — pre-cleared.",
+      decided_by: "white@demo",
+    },
+  ];
+}
+
+export function buildAarEnvelope(opts: {
+  tenantId: string;
+  scenarioId: string;
+  events: DagEvent[];
+  overrideDecisions: OverrideDecision[];
+  replaySource: string;
+}): AarEnvelope {
+  return {
+    scenario: { tenant_id: opts.tenantId, scenario_id: opts.scenarioId, replay_source: opts.replaySource },
+    events: opts.events,
+    override_decisions: opts.overrideDecisions,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * v1 export: triggers a browser download of the AAR JSON bundle. Spec calls
+ * for an S3 upload to `s3://almighty-${tenant_id}-${env}/aar/${scenario_id}/`
+ * and a generated PDF — both deferred (no S3 SDK in the renderer; PDF via
+ * browser print is the v1 workaround).
+ */
+export function downloadAarBundle(envelope: AarEnvelope): void {
+  const blob = new Blob([JSON.stringify(envelope, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `aar-${envelope.scenario.scenario_id}-${envelope.generated_at.replace(/[:.]/g, "-")}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/web/renderer/src/components/CesiumViewerExposer.tsx
+++ b/web/renderer/src/components/CesiumViewerExposer.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import { useCesium } from "resium";
+import type { Viewer as CesiumViewer } from "cesium";
+
+type CesiumViewerExposerProps = {
+  onReady: (viewer: CesiumViewer) => void;
+};
+
+/**
+ * Helper child of <Viewer> that hands the underlying Cesium viewer back to
+ * a parent via callback. Used by AAR-side controls that need to drive the
+ * clock (multiplier, currentTime, shouldAnimate) imperatively.
+ */
+export function CesiumViewerExposer({ onReady }: CesiumViewerExposerProps) {
+  const { viewer } = useCesium();
+  useEffect(() => {
+    if (viewer) onReady(viewer);
+  }, [viewer, onReady]);
+  return null;
+}

--- a/web/renderer/src/components/EventLog.tsx
+++ b/web/renderer/src/components/EventLog.tsx
@@ -1,0 +1,53 @@
+import type { DagEvent, OverrideDecision } from "../api/aar";
+
+type Row =
+  | { kind: "event"; ts: string; data: DagEvent }
+  | { kind: "decision"; ts: string; data: OverrideDecision };
+
+type EventLogProps = {
+  events: DagEvent[];
+  overrideDecisions: OverrideDecision[];
+  onSeek: (ts: string) => void;
+};
+
+export function EventLog({ events, overrideDecisions, onSeek }: EventLogProps) {
+  const rows: Row[] = [
+    ...events.map<Row>((e) => ({ kind: "event", ts: e.ts, data: e })),
+    ...overrideDecisions.map<Row>((d) => ({ kind: "decision", ts: d.ts, data: d })),
+  ].sort((a, b) => a.ts.localeCompare(b.ts));
+
+  return (
+    <div className="event-log">
+      <h2>Event log</h2>
+      {rows.length === 0 && <p className="white-cell-hint">No events captured.</p>}
+      <ul>
+        {rows.map((row) => (
+          <li
+            key={row.kind === "event" ? row.data.event_id : row.data.decision_id}
+            className={`event-log__row event-log__row--${row.kind}`}
+            onClick={() => onSeek(row.ts)}
+            title="Click to seek timeline"
+          >
+            <span className="event-log__time">{shortTime(row.ts)}</span>
+            {row.kind === "event" ? (
+              <>
+                <span className="event-log__verb"><code>{row.data.action_verb}</code></span>
+                <span className="event-log__officer">{row.data.source_officer_type}</span>
+                <span className="event-log__turn">turn {row.data.turn}</span>
+              </>
+            ) : (
+              <>
+                <span className={`event-log__decision pill pill--${row.data.action}`}>{row.data.action}</span>
+                <span className="event-log__decision-meta">{row.data.scope} → {row.data.target_id}</span>
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function shortTime(iso: string): string {
+  return iso.slice(11, 19);
+}

--- a/web/renderer/src/components/ExportBundleButton.tsx
+++ b/web/renderer/src/components/ExportBundleButton.tsx
@@ -1,0 +1,27 @@
+import { buildAarEnvelope, downloadAarBundle, type DagEvent, type OverrideDecision } from "../api/aar";
+
+type ExportBundleButtonProps = {
+  tenantId: string;
+  scenarioId: string;
+  events: DagEvent[];
+  overrideDecisions: OverrideDecision[];
+  replaySource: string;
+};
+
+export function ExportBundleButton(props: ExportBundleButtonProps) {
+  const onClick = () => {
+    const envelope = buildAarEnvelope({
+      tenantId: props.tenantId,
+      scenarioId: props.scenarioId,
+      events: props.events,
+      overrideDecisions: props.overrideDecisions,
+      replaySource: props.replaySource,
+    });
+    downloadAarBundle(envelope);
+  };
+  return (
+    <button type="button" className="white-cell-btn white-cell-btn--primary" onClick={onClick}>
+      Export AAR bundle
+    </button>
+  );
+}

--- a/web/renderer/src/components/PlaybackControls.tsx
+++ b/web/renderer/src/components/PlaybackControls.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import type { Viewer as CesiumViewer } from "cesium";
+
+type PlaybackControlsProps = {
+  viewer: CesiumViewer | null;
+};
+
+const SPEEDS: readonly number[] = [0.5, 1, 2, 4, 8, 16];
+
+/**
+ * Drives the Cesium clock multiplier + play/pause. The native Cesium
+ * Animation widget exposes the same controls but in Cesium's chrome —
+ * this component surfaces them in the AAR's own UI so speed selection
+ * is one click instead of an analog dial.
+ */
+export function PlaybackControls({ viewer }: PlaybackControlsProps) {
+  const [multiplier, setMultiplier] = useState(1);
+  const [playing, setPlaying] = useState(false);
+
+  useEffect(() => {
+    if (!viewer) return;
+    setMultiplier(viewer.clock.multiplier);
+    setPlaying(viewer.clock.shouldAnimate);
+    const onTick = viewer.clock.onTick.addEventListener(() => {
+      // Sync local UI state if Cesium's own widget changed it.
+      if (viewer.clock.multiplier !== multiplier) setMultiplier(viewer.clock.multiplier);
+      if (viewer.clock.shouldAnimate !== playing) setPlaying(viewer.clock.shouldAnimate);
+    });
+    return () => onTick();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewer]);
+
+  if (!viewer) return null;
+
+  const setSpeed = (n: number) => {
+    viewer.clock.multiplier = n;
+    setMultiplier(n);
+  };
+  const togglePlay = () => {
+    viewer.clock.shouldAnimate = !viewer.clock.shouldAnimate;
+    setPlaying(viewer.clock.shouldAnimate);
+  };
+  const seekStart = () => {
+    viewer.clock.currentTime = viewer.clock.startTime.clone();
+  };
+
+  return (
+    <div className="playback-controls">
+      <button type="button" className="white-cell-btn" onClick={togglePlay}>
+        {playing ? "⏸ Pause" : "▶ Play"}
+      </button>
+      <button type="button" className="white-cell-btn" onClick={seekStart}>
+        ⏮ Restart
+      </button>
+      <span className="playback-controls__speed-label">Speed:</span>
+      {SPEEDS.map((s) => (
+        <button
+          key={s}
+          type="button"
+          className={`white-cell-btn ${multiplier === s ? "white-cell-btn--primary" : ""}`}
+          onClick={() => setSpeed(s)}
+        >
+          {s}×
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/renderer/src/router.tsx
+++ b/web/renderer/src/router.tsx
@@ -4,6 +4,7 @@ import { ScenarioRoot } from "./routes/ScenarioRoot";
 import { Index } from "./routes/Index";
 import { ExconConsole } from "./routes/ExconConsole";
 import { WhiteCellConsole } from "./routes/WhiteCellConsole";
+import { AarReplay } from "./routes/AarReplay";
 
 export const router = createBrowserRouter([
   {
@@ -26,6 +27,10 @@ export const router = createBrowserRouter([
       {
         path: ":tenantId/scenarios/:scenarioId/white-cell",
         element: <WhiteCellConsole />,
+      },
+      {
+        path: ":tenantId/scenarios/:scenarioId/aar",
+        element: <AarReplay />,
       },
       { path: "*", element: <Navigate to="/" replace /> },
     ],

--- a/web/renderer/src/routes/AarReplay.tsx
+++ b/web/renderer/src/routes/AarReplay.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { JulianDate, type Viewer as CesiumViewer } from "cesium";
+import { useJwtClaims } from "../auth/jwt";
+import { AccessDenied } from "../components/AccessDenied";
+import { CesiumScene } from "../components/CesiumScene";
+import { CzmlLoader } from "../components/CzmlLoader";
+import { CesiumViewerExposer } from "../components/CesiumViewerExposer";
+import { PlaybackControls } from "../components/PlaybackControls";
+import { EventLog } from "../components/EventLog";
+import { ExportBundleButton } from "../components/ExportBundleButton";
+import {
+  type DagEvent,
+  type OverrideDecision,
+  fetchEvents,
+  fixtureEvents,
+  fixtureOverrideDecisions,
+} from "../api/aar";
+
+const REPLAY_CZML_URL = "/czml/nashville-vignette.czml";
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "live"; events: DagEvent[]; count: number }
+  | { kind: "fixture"; events: DagEvent[]; reason: string }
+  | { kind: "error"; reason: string };
+
+export function AarReplay() {
+  const { tenantId, scenarioId } = useParams<{ tenantId: string; scenarioId: string }>();
+  const claims = useJwtClaims();
+
+  const [viewer, setViewer] = useState<CesiumViewer | null>(null);
+  const [load, setLoad] = useState<LoadState>({ kind: "loading" });
+  const [overrides] = useState<OverrideDecision[]>(() => fixtureOverrideDecisions());
+
+  const onViewerReady = useCallback((v: CesiumViewer) => setViewer(v), []);
+
+  useEffect(() => {
+    if (!claims || !tenantId || !scenarioId) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const live = await fetchEvents(tenantId, scenarioId);
+        if (cancelled) return;
+        if (live.length === 0) {
+          setLoad({
+            kind: "fixture",
+            events: fixtureEvents(tenantId, scenarioId),
+            reason: "control-plane returned 0 events; replaying Nashville-vignette fixture",
+          });
+        } else {
+          setLoad({ kind: "live", events: live, count: live.length });
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setLoad({
+          kind: "fixture",
+          events: fixtureEvents(tenantId, scenarioId),
+          reason: `control-plane unreachable (${err instanceof Error ? err.message : String(err)}); replaying fixture`,
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [claims, tenantId, scenarioId]);
+
+  const seek = useCallback(
+    (ts: string) => {
+      if (!viewer) return;
+      viewer.clock.currentTime = JulianDate.fromIso8601(ts);
+    },
+    [viewer],
+  );
+
+  if (!claims) {
+    return <AccessDenied required="white" actual={undefined} />;
+  }
+
+  const events = load.kind === "live" || load.kind === "fixture" ? load.events : [];
+  const replaySource =
+    load.kind === "live" ? "control-plane:/events" : load.kind === "fixture" ? REPLAY_CZML_URL : "—";
+
+  return (
+    <div className="aar">
+      <header className="aar__header">
+        <h1>After-action review</h1>
+        <div className="aar__breadcrumb">
+          tenant <code>{tenantId}</code> · scenario <code>{scenarioId}</code>
+        </div>
+        <AarStatus state={load} />
+      </header>
+
+      <div className="aar__body">
+        <aside className="aar__sidebar">
+          <EventLog events={events} overrideDecisions={overrides} onSeek={seek} />
+        </aside>
+
+        <section className="aar__map">
+          <CesiumScene>
+            <CesiumViewerExposer onReady={onViewerReady} />
+            <CzmlLoader url={REPLAY_CZML_URL} />
+          </CesiumScene>
+        </section>
+
+        <aside className="aar__actions">
+          <PlaybackControls viewer={viewer} />
+          {tenantId && scenarioId && (
+            <ExportBundleButton
+              tenantId={tenantId}
+              scenarioId={scenarioId}
+              events={events}
+              overrideDecisions={overrides}
+              replaySource={replaySource}
+            />
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function AarStatus({ state }: { state: LoadState }) {
+  if (state.kind === "loading") return <p className="white-cell-hint">loading events…</p>;
+  if (state.kind === "error") return <p className="white-cell-hint white-cell-hint--err">{state.reason}</p>;
+  if (state.kind === "fixture") return <p className="white-cell-hint white-cell-hint--warn">fixture mode: {state.reason}</p>;
+  return <p className="white-cell-hint">live mode: {state.count} events from control-plane</p>;
+}

--- a/web/renderer/src/routes/Index.tsx
+++ b/web/renderer/src/routes/Index.tsx
@@ -19,6 +19,9 @@ export function Index() {
         <li>
           <Link to="/demo/scenarios/demo/white-cell">demo / demo — white cell control</Link>
         </li>
+        <li>
+          <Link to="/demo/scenarios/demo/aar">demo / demo — after-action review</Link>
+        </li>
       </ul>
       <p className="index__hint">
         Operator consoles require a JWT with the matching <code>cell_role</code>.

--- a/web/renderer/src/styles.css
+++ b/web/renderer/src/styles.css
@@ -791,3 +791,144 @@ body,
   font-family: ui-monospace, "SF Mono", monospace;
   word-break: break-all;
 }
+
+/* ---------------- AAR replay ---------------- */
+
+.aar {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
+.aar__header {
+  padding: 12px 20px;
+  background: #181818;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.aar__header h1 {
+  margin: 0;
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  color: #eee;
+}
+
+.aar__breadcrumb {
+  margin-top: 4px;
+  font-size: 11px;
+  color: #888;
+  font-family: ui-monospace, "SF Mono", monospace;
+}
+
+.aar__body {
+  display: grid;
+  grid-template-columns: 320px 1fr 280px;
+  flex: 1;
+  min-height: 0;
+}
+
+.aar__sidebar,
+.aar__actions {
+  background: #1f1f1f;
+  border-right: 1px solid #2a2a2a;
+  overflow-y: auto;
+  padding: 12px;
+  min-height: 0;
+}
+
+.aar__actions {
+  border-right: none;
+  border-left: 1px solid #2a2a2a;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.aar__map {
+  position: relative;
+  background: #000;
+  min-height: 0;
+}
+
+.event-log h2 {
+  margin: 0 0 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #999;
+}
+
+.event-log ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.event-log__row {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 6px;
+  padding: 6px 8px;
+  font-size: 11px;
+  color: #ccc;
+  border-radius: 3px;
+  cursor: pointer;
+  margin-bottom: 2px;
+  align-items: center;
+}
+
+.event-log__row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.event-log__row--decision {
+  background: rgba(255, 184, 108, 0.06);
+}
+
+.event-log__time {
+  font-family: ui-monospace, "SF Mono", monospace;
+  color: #888;
+  font-size: 10px;
+}
+
+.event-log__verb code {
+  color: #8ec5ff;
+}
+
+.event-log__officer {
+  color: #888;
+  font-size: 10px;
+  margin-left: 6px;
+}
+
+.event-log__turn {
+  color: #666;
+  font-size: 10px;
+  margin-left: 6px;
+}
+
+.event-log__decision-meta {
+  color: #aaa;
+  font-size: 11px;
+  margin-left: 6px;
+  font-family: ui-monospace, "SF Mono", monospace;
+}
+
+.playback-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+  background: #181818;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+  padding: 8px;
+}
+
+.playback-controls__speed-label {
+  font-size: 11px;
+  color: #888;
+  margin-left: 4px;
+  margin-right: 2px;
+}


### PR DESCRIPTION
## Summary

Two halves, one PR:

**control-plane** — adds the missing read-only events endpoint that WS-506 said to "add to control-plane if missing":
- \`GET /tenants/:id/scenarios/:sid/events\` — tenant-scoped via the same \`requireOwnTenant\` guard used everywhere else; all cell roles can read (review surface). Supports \`since_ts\` / \`until_ts\` / \`limit\` query params, ordered by \`ts ASC\`.
- \`@fastify/cors\` registered so the renderer (Vite :5173) can hit the API (:4000) cross-origin in dev. v1 reflects request origin; production should pin via env.
- 9 new integration tests (66 → 75 in this service): happy path, full cell-role matrix, cross-tenant denial, \`since_ts\` / \`until_ts\` filtering, missing-auth → 401.
- Wrapped \`pnpm dev\` and \`pnpm migrate\` in \`dotenv-cli\` so they actually pick up \`.env\` after \`cp .env.example .env\` (caught while verifying — node-pg-migrate doesn't auto-load).

**renderer** — new \`/:tenantId/scenarios/:scenarioId/aar\` route:
- Three-pane layout: EventLog (left), Cesium replay (center), PlaybackControls + Export (right).
- \`AarReplay\` calls \`fetchEvents()\` against the new control-plane endpoint; falls back to a fixture event log (Nashville-vignette tactical sequence) on 4xx / 0-events / unreachable. Status banner names the active mode + reason.
- Cesium plays back \`czml/demos/nashville-vignette.czml\` as the canonical AAR replay source. \`CesiumViewerExposer\` hands the underlying viewer to the parent so \`PlaybackControls\` can drive \`viewer.clock.multiplier\` / \`shouldAnimate\` / \`currentTime\` imperatively.
- \`PlaybackControls\`: ▶ Play / ⏸ Pause / ⏮ Restart + 0.5× / 1× / 2× / 4× / 8× / 16× speed presets.
- \`EventLog\`: 7 events + 2 override decisions (synthetic for now), interleaved and sorted by \`ts\`. Click any row → seek timeline to that timestamp.
- \`ExportBundleButton\`: downloads a JSON AAR envelope (events + override decisions + scenario metadata + \`generated_at\`). S3 upload + PDF generation deferred per spec — documented in \`api/aar.ts\`.

### Synthetic surfaces still in the PR (intentional)
- Override decisions are synthetic. Once WS-303 emits \`override_decision\`-tagged events into the events table, derive them from the same \`/events\` fetch — wire is one commit on \`api/aar.ts\`.
- AAR runs in fixture mode unless (a) you mint a properly HS256-signed JWT and (b) the events table has rows. Both are out-of-scope for this PR; covered by WS-601 integration vignette.

Closes #31.

## Test plan
- [ ] \`docker compose up -d postgres\`
- [ ] \`cd services/control-plane && pnpm install && cp .env.example .env && pnpm migrate && pnpm test\` → 75/75 pass
- [ ] \`pnpm dev\` → control-plane on :4000
- [ ] \`cd web/renderer && pnpm dev\` → renderer on :5173
- [ ] Visit \`/\` → fifth link "after-action review" present
- [ ] Visit \`/demo/scenarios/demo/aar\` → ACCESS DENIED if no JWT; set one via the form
- [ ] AAR loads with status banner reading either "live mode: N events" or "fixture mode: …"
- [ ] Hit ▶ Play, switch to 8× → vignette plays back fast
- [ ] Click any row in the event log → timeline seeks
- [ ] Click Export AAR bundle → \`aar-demo-<ts>.json\` downloads